### PR TITLE
removing metrics port etc

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 approvers:
 - deads2k
 - pmorie
+- qiujian16
 
 reviewers:
 - deads2k

--- a/deploy/hub/hub_controller_clusterrole.yaml
+++ b/deploy/hub/hub_controller_clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:open-cluster-management:hub
+  name: open-cluster-management:hub
 rules:
 # Allow hub to monitor and update status of csr
 - apiGroups: ["certificates.k8s.io"]

--- a/deploy/hub/hub_controller_clusterrole.yaml
+++ b/deploy/hub/hub_controller_clusterrole.yaml
@@ -38,7 +38,7 @@ rules:
 - apiGroups: ["register.open-cluster-management.io"]
   resources: ["managedclusters/accept"]
   verbs: ["update"]
-# Allow hub to read cluster version
+# Allow to query the CVO on the Hub Cluster to get the ClusterId
 - apiGroups: ["config.openshift.io"]
   resources: ["clusterversions"]
   verbs: ["get"]  

--- a/deploy/hub/hub_controller_clusterrole_binding.yaml
+++ b/deploy/hub/hub_controller_clusterrole_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:open-cluster-management:hub
+  name: open-cluster-management:hub
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:open-cluster-management:hub
+  name: open-cluster-management:hub
 subjects:
   - kind: ServiceAccount
     name: hub-sa

--- a/deploy/spoke/clusterrole.yaml
+++ b/deploy/spoke/clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: open-cluster-management:spoke
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "configmaps", "secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]

--- a/deploy/spoke/clusterrole_binding.yaml
+++ b/deploy/spoke/clusterrole_binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:open-cluster-management:spoke
+  name: open-cluster-management:spoke
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/spoke/kustomization.yaml
+++ b/deploy/spoke/kustomization.yaml
@@ -27,7 +27,10 @@ namespace: open-cluster-management
 resources:
 - ./namespace.yaml
 - ./service_account.yaml
+- ./clusterrole.yaml
 - ./clusterrole_binding.yaml
+- ./role.yaml
+- ./role_binding.yaml
 - ./deployment.yaml
 - ./secret.yaml
 

--- a/deploy/spoke/role.yaml
+++ b/deploy/spoke/role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: open-cluster-management:registration-agent
+  namespace: open-cluster-management
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["", "events.k8s.io"]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]

--- a/deploy/spoke/role_binding.yaml
+++ b/deploy/spoke/role_binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: open-cluster-management:spoke
+  name: open-cluster-management:registration-agent
+  namespace: open-cluster-management
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: open-cluster-management:spoke
+  kind: Role
+  name: open-cluster-management:registration-agent
 subjects:
   - kind: ServiceAccount
     name: spoke-agent-sa
     namespace: open-cluster-management
-  

--- a/deploy/webhook/clusterrole.yaml
+++ b/deploy/webhook/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:open-cluster-management:managedcluster-admission
+  name: open-cluster-management:managedcluster-admission
 rules:
 # Allow managedcluster admission to get/list/watch configmaps
 - apiGroups: [""]

--- a/deploy/webhook/clusterrole_binding.yaml
+++ b/deploy/webhook/clusterrole_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:open-cluster-management:managedcluster-admission
+  name: open-cluster-management:managedcluster-admission
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:open-cluster-management:managedcluster-admission
+  name: open-cluster-management:managedcluster-admission
 subjects:
   - kind: ServiceAccount
     name: managedcluster-admission-sa

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/open-cluster-management/registration
 go 1.13
 
 require (
-	github.com/davecgh/go-spew v1.1.1
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -302,14 +302,11 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.8.1 h1:C5Dqfs/LeauYDX0jJXIe2SWmwCbGzx9yF8C8xy3Lh34=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
-
 github.com/open-cluster-management/api v0.0.0-20200602195039-a516cac2e038 h1:ZpSgcQERvBBvfwqhdPbxIami9gZpX+RwjNPqwx4+axY=
 github.com/open-cluster-management/api v0.0.0-20200602195039-a516cac2e038/go.mod h1:+vUECYB7WkfCb52r0J7rxgD1mseSGAqGi8rTLLRcbgw=
-github.com/open-cluster-management/api v0.0.0-20200629211334-8be047b65c52 h1:8+Qh4L7ijoYK0wKM3Whjge53IVhL2fVWRbuUjy5kMUM=
-
 github.com/open-cluster-management/api v0.0.0-20200610161514-939cead3902c h1:UY7VEmlpib52/tI6lP60c21cGGSNJbX1terjoWOhJ0M=
 github.com/open-cluster-management/api v0.0.0-20200610161514-939cead3902c/go.mod h1:+vUECYB7WkfCb52r0J7rxgD1mseSGAqGi8rTLLRcbgw=
-
+github.com/open-cluster-management/api v0.0.0-20200629211334-8be047b65c52 h1:8+Qh4L7ijoYK0wKM3Whjge53IVhL2fVWRbuUjy5kMUM=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -586,10 +583,8 @@ k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apimachinery v0.18.3/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
-
 k8s.io/apimachinery v0.18.5 h1:Lh6tgsM9FMkC12K5T5QjRm7rDs6aQN5JHkA0JomULDM=
 k8s.io/apiserver v0.18.0/go.mod h1:3S2O6FeBBd6XTo0njUrLxiqk8GNy6wWOftjhJcXYnjw=
-
 k8s.io/apiserver v0.18.2 h1:fwKxdTWwwYhxvtjo0UUfX+/fsitsNtfErPNegH2x9ic=
 k8s.io/apiserver v0.18.2/go.mod h1:Xbh066NqrZO8cbsoenCwyDJ1OSi8Ag8I2lezeHxzwzw=
 k8s.io/apiserver v0.18.3 h1:BVjccwKP/kEqY+ResOyWs0EKs7f4XL0d0E5GkU3uiqI=
@@ -598,17 +593,16 @@ k8s.io/client-go v0.18.2 h1:aLB0iaD4nmwh7arT2wIn+lMnAq7OswjaejkQ8p9bBYE=
 k8s.io/client-go v0.18.2/go.mod h1:Xcm5wVGXX9HAA2JJ2sSBUn3tCJ+4SVlCbl2MNNv+CIU=
 k8s.io/client-go v0.18.3 h1:QaJzz92tsN67oorwzmoB0a9r9ZVHuD5ryjbCKP0U22k=
 k8s.io/client-go v0.18.3/go.mod h1:4a/dpQEvzAhT1BbuWW09qvIaGw6Gbu1gZYiQZIi1DMw=
-
 k8s.io/client-go v1.5.1 h1:XaX/lo2/u3/pmFau8HN+sB5C/b4dc4Dmm2eXjBH4p1E=
 k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/code-generator v0.18.0/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
-
 k8s.io/code-generator v0.18.2/go.mod h1:+UHX5rSbxmR8kzS+FAv7um6dtYrZokQvjHpDSYRVkTc=
 k8s.io/code-generator v0.18.3/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8b6c=
 k8s.io/component-base v0.18.2 h1:SJweNZAGcUvsypLGNPNGeJ9UgPZQ6+bW+gEHe8uyh/Y=
 k8s.io/component-base v0.18.2/go.mod h1:kqLlMuhJNHQ9lz8Z7V5bxUUtjFZnrypArGl58gmDfUM=
 k8s.io/component-base v0.18.3 h1:QXq+P4lgi4LCIREya1RDr5gTcBaVFhxEcALir3QCSDA=
 k8s.io/component-base v0.18.3/go.mod h1:bp5GzGR0aGkYEfTj+eTY0AN/vXTgkJdQXjNTTVUaa3k=
+k8s.io/component-base v0.18.5 h1:QIz2xFax8W5XQREoNcP/MHgnt4ClgfZ837Qx9yCeCzA=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -203,7 +203,7 @@ func CleanUpManagedClusterManifests(
 	return errorhelpers.NewMultiLineAggregate(errs)
 }
 
-// CleanUpGroupFromClusterRoleBindings search all clusterrolebings for managed cluster group and remove the subject entry
+// CleanUpGroupFromClusterRoleBindings search all clusterrolebindings for managed cluster group and remove the subject entry
 // or delete the clusterrolebinding if it's the only subject.
 func CleanUpGroupFromClusterRoleBindings(
 	ctx context.Context,
@@ -248,7 +248,7 @@ func CleanUpGroupFromClusterRoleBindings(
 	return nil
 }
 
-// CleanUpGroupFromRoleBindings search all rolebings for managed cluster group and remove the subject entry
+// CleanUpGroupFromRoleBindings search all rolebindings for managed cluster group and remove the subject entry
 // or delete the rolebinding if it's the only subject.
 func CleanUpGroupFromRoleBindings(
 	ctx context.Context,

--- a/pkg/helpers/testing/assertion.go
+++ b/pkg/helpers/testing/assertion.go
@@ -1,0 +1,193 @@
+package testing
+
+import (
+	"reflect"
+	"testing"
+
+	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	certv1beta1 "k8s.io/api/certificates/v1beta1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/utils/diff"
+)
+
+// AssertError asserts the actual error representation is the same with the expected,
+// if the expected error representation is empty, the actual should be nil
+func AssertError(t *testing.T, actual error, expectedErr string) {
+	if len(expectedErr) > 0 && actual == nil {
+		t.Errorf("expected %q error", expectedErr)
+		return
+	}
+	if len(expectedErr) > 0 && actual != nil && actual.Error() != expectedErr {
+		t.Errorf("expected %q error, but got %q", expectedErr, actual.Error())
+		return
+	}
+	if len(expectedErr) == 0 && actual != nil {
+		t.Errorf("unexpected err: %v", actual)
+		return
+	}
+}
+
+// AssertActions asserts the actual actions have the expected action verb
+func AssertActions(t *testing.T, actualActions []clienttesting.Action, expectedVerbs ...string) {
+	if len(actualActions) != len(expectedVerbs) {
+		t.Errorf("expected %d call but got: %#v", len(expectedVerbs), actualActions)
+	}
+	for i, expected := range expectedVerbs {
+		if actualActions[i].GetVerb() != expected {
+			t.Errorf("expected %s action but got: %#v", expected, actualActions[i])
+		}
+	}
+}
+
+// AssertNoActions asserts no actions are happened
+func AssertNoActions(t *testing.T, actualActions []clienttesting.Action) {
+	AssertActions(t, actualActions)
+}
+
+// AssertUpdateActions asserts the actions are get-then-update action
+func AssertUpdateActions(t *testing.T, actions []clienttesting.Action) {
+	for i := 0; i < len(actions); i = i + 2 {
+		if actions[i].GetVerb() != "get" {
+			t.Errorf("expected action %d is get, but %v", i, actions[i])
+		}
+		if actions[i+1].GetVerb() != "update" {
+			t.Errorf("expected action %d is update, but %v", i, actions[i+1])
+		}
+	}
+}
+
+// AssertNoMoreUpdates asserts only one update action in given actions
+func AssertNoMoreUpdates(t *testing.T, actions []clienttesting.Action) {
+	updateActions := 0
+	for _, action := range actions {
+		if action.GetVerb() == "update" {
+			updateActions++
+		}
+	}
+	if updateActions != 1 {
+		t.Errorf("expected there is only one update action, but failed")
+	}
+}
+
+// AssertFinalizers asserts the given runtime object has the expected finalizers
+func AssertFinalizers(t *testing.T, obj runtime.Object, finalizers []string) {
+	accessor, _ := meta.Accessor(obj)
+	actual := accessor.GetFinalizers()
+	if len(actual) == 0 && len(finalizers) == 0 {
+		return
+	}
+	if !reflect.DeepEqual(actual, finalizers) {
+		t.Fatal(diff.ObjectDiff(actual, finalizers))
+	}
+}
+
+// AssertManagedClusterCondition asserts the actual managed cluster conditions has
+// the expected condition
+func AssertManagedClusterCondition(
+	t *testing.T,
+	actualConditions []clusterv1.StatusCondition,
+	expectedCondition clusterv1.StatusCondition) {
+	var cond *clusterv1.StatusCondition
+	for i := range actualConditions {
+		condition := actualConditions[i]
+		if condition.Type == expectedCondition.Type {
+			cond = &condition
+			break
+		}
+	}
+	if cond == nil {
+		t.Errorf("expected condition %s but got: %s", expectedCondition.Type, cond.Type)
+	}
+	if cond.Status != expectedCondition.Status {
+		t.Errorf("expected status %s but got: %s", expectedCondition.Status, cond.Status)
+	}
+	if cond.Reason != expectedCondition.Reason {
+		t.Errorf("expected reason %s but got: %s", expectedCondition.Reason, cond.Reason)
+	}
+	if cond.Message != expectedCondition.Message {
+		t.Errorf("expected message %s but got: %s", expectedCondition.Message, cond.Message)
+	}
+}
+
+// AssertManagedClusterClientConfigs asserts the actual managed cluster client configs are the
+// same wiht the expected
+func AssertManagedClusterClientConfigs(t *testing.T, actual, expected []clusterv1.ClientConfig) {
+	if len(actual) == 0 && len(expected) == 0 {
+		return
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("expected client configs %#v but got: %#v", expected, actual)
+	}
+}
+
+// AssertManagedClusterStatus sserts the actual managed cluster status is the same
+// wiht the expected
+func AssertManagedClusterStatus(t *testing.T, actual, expected clusterv1.ManagedClusterStatus) {
+	if !reflect.DeepEqual(actual.Version, expected.Version) {
+		t.Errorf("expected version %#v but got: %#v", expected.Version, actual.Version)
+	}
+	if !reflect.DeepEqual(actual.Capacity["cpu"], expected.Capacity["cpu"]) {
+		t.Errorf("expected cpu capacity %#v but got: %#v", expected.Capacity["cpu"], actual.Capacity["cpu"])
+	}
+	if !reflect.DeepEqual(actual.Capacity["memory"], expected.Capacity["memory"]) {
+		t.Errorf("expected memory capacity %#v but got: %#v", expected.Capacity["memory"], actual.Capacity["memory"])
+	}
+	if !reflect.DeepEqual(actual.Allocatable["cpu"], expected.Allocatable["cpu"]) {
+		t.Errorf("expected cpu allocatable %#v but got: %#v", expected.Allocatable["cpu"], actual.Allocatable["cpu"])
+	}
+	if !reflect.DeepEqual(actual.Allocatable["memory"], expected.Allocatable["memory"]) {
+		t.Errorf("expected memory alocatabel %#v but got: %#v", expected.Allocatable["memory"], actual.Allocatable["memory"])
+	}
+}
+
+// AssertSubjectAccessReviewObj asserts the given runtime object is the
+// authorization SubjectAccessReview object
+func AssertSubjectAccessReviewObj(t *testing.T, actual runtime.Object) {
+	_, ok := actual.(*authorizationv1.SubjectAccessReview)
+	if !ok {
+		t.Errorf("expected subjectaccessreview object, but got: %#v", actual)
+	}
+}
+
+// AssertCSRCondition asserts the actual csr conditions has the expected condition
+func AssertCSRCondition(
+	t *testing.T,
+	actualConditions []certv1beta1.CertificateSigningRequestCondition,
+	expectedCondition certv1beta1.CertificateSigningRequestCondition) {
+	var cond *certv1beta1.CertificateSigningRequestCondition
+	for i := range actualConditions {
+		condition := actualConditions[i]
+		if condition.Type == expectedCondition.Type {
+			cond = &condition
+			break
+		}
+	}
+	if cond == nil {
+		t.Errorf("expected condition %s but got: %s", expectedCondition.Type, cond.Type)
+	}
+	if cond.Reason != expectedCondition.Reason {
+		t.Errorf("expected reason %s but got: %s", expectedCondition.Reason, cond.Reason)
+	}
+	if cond.Message != expectedCondition.Message {
+		t.Errorf("expected message %s but got: %s", expectedCondition.Message, cond.Message)
+	}
+}
+
+// AssertLeaseUpdated asserts the lease obj is updated
+func AssertLeaseUpdated(t *testing.T, lease, lastLease *coordinationv1.Lease) {
+	if lease == nil || lastLease == nil {
+		t.Errorf("expected lease objects are not nil, but failed")
+	}
+	if (lease.Namespace != lastLease.Namespace) || (lease.Name != lastLease.Name) {
+		t.Errorf("expected two lease objects are same lease, but failed")
+	}
+	if !lease.Spec.RenewTime.BeforeTime(&metav1.Time{Time: lastLease.Spec.RenewTime.Time}) {
+		t.Errorf("expected lease updated, but failed")
+	}
+}

--- a/pkg/helpers/testing/testinghelpers.go
+++ b/pkg/helpers/testing/testinghelpers.go
@@ -1,16 +1,45 @@
 package testing
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"math/rand"
+	"net"
 	"testing"
 	"time"
 
-	"k8s.io/client-go/util/workqueue"
-
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
 	workapiv1 "github.com/open-cluster-management/api/work/v1"
+
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+
+	certv1beta1 "k8s.io/api/certificates/v1beta1"
+	coordv1 "k8s.io/api/coordination/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kubeversion "k8s.io/client-go/pkg/version"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	"k8s.io/client-go/util/workqueue"
+)
+
+const (
+	TestLeaseDurationSeconds int32 = 1
+	TestManagedClusterName         = "testmanagedcluster"
 )
 
 type FakeSyncContext struct {
@@ -18,6 +47,10 @@ type FakeSyncContext struct {
 	recorder  events.Recorder
 	queue     workqueue.RateLimitingInterface
 }
+
+func (f FakeSyncContext) Queue() workqueue.RateLimitingInterface { return f.queue }
+func (f FakeSyncContext) QueueKey() string                       { return f.spokeName }
+func (f FakeSyncContext) Recorder() events.Recorder              { return f.recorder }
 
 func NewFakeSyncContext(t *testing.T, clusterName string) *FakeSyncContext {
 	return &FakeSyncContext{
@@ -27,9 +60,128 @@ func NewFakeSyncContext(t *testing.T, clusterName string) *FakeSyncContext {
 	}
 }
 
-func (f FakeSyncContext) Queue() workqueue.RateLimitingInterface { return f.queue }
-func (f FakeSyncContext) QueueKey() string                       { return f.spokeName }
-func (f FakeSyncContext) Recorder() events.Recorder              { return f.recorder }
+func NewManagedCluster() *clusterv1.ManagedCluster {
+	return &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: TestManagedClusterName,
+		},
+	}
+}
+
+func NewAcceptingManagedCluster() *clusterv1.ManagedCluster {
+	managedCluster := NewManagedCluster()
+	managedCluster.Finalizers = []string{"cluster.open-cluster-management.io/api-resource-cleanup"}
+	managedCluster.Spec.HubAcceptsClient = true
+	return managedCluster
+}
+
+func NewAcceptedManagedCluster() *clusterv1.ManagedCluster {
+	managedCluster := NewAcceptingManagedCluster()
+	acceptedCondtion := NewManagedClusterCondition(
+		clusterv1.ManagedClusterConditionHubAccepted,
+		"True",
+		"HubClusterAdminAccepted",
+		"Accepted by hub cluster admin",
+		nil,
+	)
+	managedCluster.Status.Conditions = append(managedCluster.Status.Conditions, acceptedCondtion)
+	managedCluster.Spec.LeaseDurationSeconds = TestLeaseDurationSeconds
+	return managedCluster
+}
+
+func NewAvailableManagedCluster() *clusterv1.ManagedCluster {
+	managedCluster := NewAcceptedManagedCluster()
+	availableCondtion := NewManagedClusterCondition(
+		clusterv1.ManagedClusterConditionAvailable,
+		"True",
+		"ManagedClusterAvailable",
+		"Managed cluster is available",
+		nil,
+	)
+	managedCluster.Status.Conditions = append(managedCluster.Status.Conditions, availableCondtion)
+	return managedCluster
+}
+
+func NewJoinedManagedCluster() *clusterv1.ManagedCluster {
+	managedCluster := NewAcceptedManagedCluster()
+	joinedCondtion := NewManagedClusterCondition(
+		clusterv1.ManagedClusterConditionJoined,
+		"True",
+		"ManagedClusterJoined",
+		"Managed cluster joined",
+		nil,
+	)
+	managedCluster.Status.Conditions = append(managedCluster.Status.Conditions, joinedCondtion)
+	return managedCluster
+}
+
+func NewManagedClusterWithStatus(capacity, allocatable corev1.ResourceList) *clusterv1.ManagedCluster {
+	managedCluster := NewJoinedManagedCluster()
+	managedCluster.Status.Capacity = clusterv1.ResourceList{
+		"cpu":    capacity.Cpu().DeepCopy(),
+		"memory": capacity.Memory().DeepCopy(),
+	}
+	managedCluster.Status.Allocatable = clusterv1.ResourceList{
+		"cpu":    allocatable.Cpu().DeepCopy(),
+		"memory": allocatable.Memory().DeepCopy(),
+	}
+	managedCluster.Status.Version = clusterv1.ManagedClusterVersion{
+		Kubernetes: kubeversion.Get().GitVersion,
+	}
+	return managedCluster
+}
+
+func NewDeniedManagedCluster() *clusterv1.ManagedCluster {
+	managedCluster := NewAcceptedManagedCluster()
+	managedCluster.Spec.HubAcceptsClient = false
+	return managedCluster
+}
+
+func NewDeletingManagedCluster() *clusterv1.ManagedCluster {
+	now := metav1.Now()
+	return &clusterv1.ManagedCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              TestManagedClusterName,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"cluster.open-cluster-management.io/api-resource-cleanup"},
+		},
+	}
+}
+
+func NewManagedClusterCondition(name, status, reason, message string, lastTransition *metav1.Time) clusterv1.StatusCondition {
+	ret := clusterv1.StatusCondition{
+		Type:    name,
+		Status:  metav1.ConditionStatus(status),
+		Reason:  reason,
+		Message: message,
+	}
+	if lastTransition != nil {
+		ret.LastTransitionTime = *lastTransition
+	}
+	return ret
+}
+
+func NewManagedClusterLease(renewTime time.Time) *coordv1.Lease {
+	return &coordv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("cluster-lease-%s", TestManagedClusterName),
+			Namespace: TestManagedClusterName,
+		},
+		Spec: coordv1.LeaseSpec{
+			RenewTime: &metav1.MicroTime{Time: renewTime},
+		},
+	}
+}
+
+func NewNamespace(name string, terminated bool) *corev1.Namespace {
+	namespace := &corev1.Namespace{}
+	namespace.Name = name
+	if terminated {
+		now := metav1.Now()
+		namespace.DeletionTimestamp = &now
+	}
+	return namespace
+}
 
 func NewManifestWork(namespace, name string, finalizers []string, deletionTimestamp *metav1.Time) *workapiv1.ManifestWork {
 	work := &workapiv1.ManifestWork{
@@ -40,21 +192,242 @@ func NewManifestWork(namespace, name string, finalizers []string, deletionTimest
 			DeletionTimestamp: deletionTimestamp,
 		},
 	}
-
 	return work
 }
 
-func NewDeletionTimestamp(offset time.Duration) *metav1.Time {
-	return &metav1.Time{
-		Time: metav1.Now().Add(offset),
+func NewRole(namespace, name string, finalizers []string, terminated bool) *rbacv1.Role {
+	role := &rbacv1.Role{}
+	role.Namespace = namespace
+	role.Name = name
+	role.Finalizers = finalizers
+	if terminated {
+		now := metav1.Now()
+		role.DeletionTimestamp = &now
+	}
+	return role
+}
+
+func NewRoleBinding(namespace, name string, finalizers []string, terminated bool) *rbacv1.RoleBinding {
+	rolebinding := &rbacv1.RoleBinding{}
+	rolebinding.Namespace = namespace
+	rolebinding.Name = name
+	rolebinding.Finalizers = finalizers
+	if terminated {
+		now := metav1.Now()
+		rolebinding.DeletionTimestamp = &now
+	}
+	return rolebinding
+}
+
+func NewResourceList(cpu, mem int) corev1.ResourceList {
+	return corev1.ResourceList{
+		corev1.ResourceCPU:    *resource.NewQuantity(int64(cpu), resource.DecimalExponent),
+		corev1.ResourceMemory: *resource.NewQuantity(int64(1024*1024*mem), resource.BinarySI),
 	}
 }
 
-func NewManagedCluster(name string, deletionTime *metav1.Time) *clusterv1.ManagedCluster {
-	return &clusterv1.ManagedCluster{
+func NewNode(name string, capacity, allocatable corev1.ResourceList) *corev1.Node {
+	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              name,
-			DeletionTimestamp: deletionTime,
+			Name: name,
 		},
+		Status: corev1.NodeStatus{
+			Capacity:    capacity,
+			Allocatable: allocatable,
+		},
+	}
+}
+
+func NewUnstructuredObj(apiVersion, kind, namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"namespace": namespace,
+				"name":      name,
+			},
+		},
+	}
+}
+
+type CSRHolder struct {
+	Name         string
+	Labels       map[string]string
+	SignerName   *string
+	CN           string
+	Orgs         []string
+	Username     string
+	ReqBlockType string
+}
+
+func NewCSR(holder CSRHolder) *certv1beta1.CertificateSigningRequest {
+	insecureRand := rand.New(rand.NewSource(0))
+	pk, err := ecdsa.GenerateKey(elliptic.P256(), insecureRand)
+	if err != nil {
+		panic(err)
+	}
+	csrb, err := x509.CreateCertificateRequest(insecureRand, &x509.CertificateRequest{
+		Subject: pkix.Name{
+			CommonName:   holder.CN,
+			Organization: holder.Orgs,
+		},
+		DNSNames:       []string{},
+		EmailAddresses: []string{},
+		IPAddresses:    []net.IP{},
+	}, pk)
+	if err != nil {
+		panic(err)
+	}
+	return &certv1beta1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         holder.Name,
+			GenerateName: "csr-",
+			Labels:       holder.Labels,
+		},
+		Spec: certv1beta1.CertificateSigningRequestSpec{
+			Username:   holder.Username,
+			Usages:     []certv1beta1.KeyUsage{},
+			SignerName: holder.SignerName,
+			Request:    pem.EncodeToMemory(&pem.Block{Type: holder.ReqBlockType, Bytes: csrb}),
+		},
+	}
+}
+
+func NewDeniedCSR(holder CSRHolder) *certv1beta1.CertificateSigningRequest {
+	csr := NewCSR(holder)
+	csr.Status.Conditions = append(csr.Status.Conditions, certv1beta1.CertificateSigningRequestCondition{
+		Type: certv1beta1.CertificateDenied,
+	})
+	return csr
+}
+
+func NewApprovedCSR(holder CSRHolder) *certv1beta1.CertificateSigningRequest {
+	csr := NewCSR(holder)
+	csr.Status.Conditions = append(csr.Status.Conditions, certv1beta1.CertificateSigningRequestCondition{
+		Type: certv1beta1.CertificateApproved,
+	})
+	return csr
+}
+
+func NewKubeconfig(key, cert []byte) []byte {
+	var clientKey, clientCertificate string
+	var clientKeyData, clientCertificateData []byte
+	if key != nil {
+		clientKeyData = key
+	} else {
+		clientKey = "tls.key"
+	}
+	if cert != nil {
+		clientCertificateData = cert
+	} else {
+		clientCertificate = "tls.crt"
+	}
+
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{"default-cluster": {
+			Server:                "https://127.0.0.1:6001",
+			InsecureSkipTLSVerify: true,
+		}},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{"default-auth": {
+			ClientCertificate:     clientCertificate,
+			ClientCertificateData: clientCertificateData,
+			ClientKey:             clientKey,
+			ClientKeyData:         clientKeyData,
+		}},
+		Contexts: map[string]*clientcmdapi.Context{"default-context": {
+			Cluster:   "default-cluster",
+			AuthInfo:  "default-auth",
+			Namespace: "default",
+		}},
+		CurrentContext: "default-context",
+	}
+
+	kubeconfigData, err := clientcmd.Write(kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+	return kubeconfigData
+}
+
+type TestCert struct {
+	Cert []byte
+	Key  []byte
+}
+
+func NewHubKubeconfigSecret(namespace, name, resourceVersion string, cert *TestCert, data map[string][]byte) *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            name,
+			ResourceVersion: resourceVersion,
+		},
+		Data: data,
+	}
+	if cert != nil && cert.Cert != nil {
+		secret.Data["tls.crt"] = cert.Cert
+	}
+	if cert != nil && cert.Key != nil {
+		secret.Data["tls.key"] = cert.Key
+	}
+	return secret
+}
+
+func NewTestCert(commonName string, duration time.Duration) *TestCert {
+	caKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	caCert, err := certutil.NewSelfSignedCACert(certutil.Config{CommonName: "open-cluster-management.io"}, caKey)
+	if err != nil {
+		panic(err)
+	}
+
+	key, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+
+	certDERBytes, err := x509.CreateCertificate(
+		cryptorand.Reader,
+		&x509.Certificate{
+			Subject: pkix.Name{
+				CommonName: commonName,
+			},
+			SerialNumber: big.NewInt(1),
+			NotBefore:    caCert.NotBefore,
+			NotAfter:     time.Now().Add(duration).UTC(),
+			KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		},
+		caCert,
+		key.Public(),
+		caKey,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	cert, err := x509.ParseCertificate(certDERBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return &TestCert{
+		Cert: pem.EncodeToMemory(&pem.Block{
+			Type:  certutil.CertificateBlockType,
+			Bytes: cert.Raw,
+		}),
+		Key: pem.EncodeToMemory(&pem.Block{
+			Type:  keyutil.RSAPrivateKeyBlockType,
+			Bytes: x509.MarshalPKCS1PrivateKey(key),
+		}),
+	}
+}
+
+func WriteFile(filename string, data []byte) {
+	if err := ioutil.WriteFile(filename, data, 0644); err != nil {
+		panic(err)
 	}
 }

--- a/pkg/hub/csr/controller.go
+++ b/pkg/hub/csr/controller.go
@@ -149,7 +149,7 @@ func isSpokeClusterClientCertRenewal(csr *certificatesv1beta1.CertificateSigning
 
 	x509cr, err := x509.ParseCertificateRequest(block.Bytes)
 	if err != nil {
-		klog.V(4).Infof("csr %q was not recognized: %w", csr.Name, err)
+		klog.V(4).Infof("csr %q was not recognized: %v", csr.Name, err)
 		return false
 	}
 

--- a/pkg/hub/custommetrics/custommetrics.go
+++ b/pkg/hub/custommetrics/custommetrics.go
@@ -72,7 +72,7 @@ func getK8sConfig(masterURL string, kubeconfig string) (*restclient.Config, erro
 
 func getDynClient() (dynamic.Interface, error) {
 
-	config, err := getK8sConfig()
+	config, err := getK8sConfig("", "")
 	if err != nil {
 		panic(err.Error())
 	}

--- a/pkg/hub/custommetrics/custommetrics.go
+++ b/pkg/hub/custommetrics/custommetrics.go
@@ -71,12 +71,11 @@ func getHubClusterId(c dynamic.Interface) {
 		panic(errCv.Error())
 	}
 	hubID = string(cv.Spec.ClusterID)
-	klog.Infof("Hub id of this ACM Server is " + hubID)
 
 }
 
 func addCluster(obj interface{}) {
-	klog.Info("Adding Managed Clusters ####################")
+
 	j, err := json.Marshal(obj.(*unstructured.Unstructured))
 	if err != nil {
 		klog.Warning("Error on ManagedCluster marshal.")
@@ -97,7 +96,6 @@ func addCluster(obj interface{}) {
 }
 
 func delCluster(obj interface{}) {
-	klog.Info("Deleting Managed Clusters ####################")
 
 	j, err := json.Marshal(obj.(*unstructured.Unstructured))
 	if err != nil {

--- a/pkg/hub/custommetrics/custommetrics_test.go
+++ b/pkg/hub/custommetrics/custommetrics_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func TestGetStaticData(t *testing.T) {
+func TestGetHubClusterId(t *testing.T) {
 
 	s := scheme.Scheme
 	if err := ocinfrav1.AddToScheme(s); err != nil {
@@ -25,7 +25,7 @@ func TestGetStaticData(t *testing.T) {
 	}
 
 	c := fake.NewSimpleDynamicClient(s, cv)
-	getStaticData(c)
+	getHubClusterId(c)
 	if hubID != id {
 		t.Fatal("Failed to get cluster id")
 	}

--- a/pkg/hub/lease/controller_test.go
+++ b/pkg/hub/lease/controller_test.go
@@ -8,10 +8,8 @@ import (
 	clusterfake "github.com/open-cluster-management/api/client/cluster/clientset/versioned/fake"
 	clusterinformers "github.com/open-cluster-management/api/client/cluster/informers/externalversions"
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
-	"github.com/open-cluster-management/registration/pkg/helpers"
 	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
 
-	coordv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeinformers "k8s.io/client-go/informers"
@@ -27,48 +25,47 @@ func TestSync(t *testing.T) {
 		clusters        []runtime.Object
 		clusterLeases   []runtime.Object
 		validateActions func(t *testing.T, leaseActions, clusterActions []clienttesting.Action)
-		expectedErr     string
 	}{
 		{
 			name:          "sync unaccepted managed cluster",
-			clusters:      []runtime.Object{newManagedCluster()},
+			clusters:      []runtime.Object{testinghelpers.NewManagedCluster()},
 			clusterLeases: []runtime.Object{},
 			validateActions: func(t *testing.T, leaseActions, clusterActions []clienttesting.Action) {
-				assertActions(t, leaseActions)
-				assertActions(t, clusterActions)
+				testinghelpers.AssertNoActions(t, leaseActions)
+				testinghelpers.AssertNoActions(t, clusterActions)
 			},
 		},
 		{
 			name:          "there is no lease for a managed cluster",
-			clusters:      []runtime.Object{newManagedCluster(newAcceptedCondtion())},
+			clusters:      []runtime.Object{testinghelpers.NewAcceptedManagedCluster()},
 			clusterLeases: []runtime.Object{},
 			validateActions: func(t *testing.T, leaseActions, clusterActions []clienttesting.Action) {
-				assertActions(t, leaseActions, "create")
-				assertActions(t, clusterActions)
+				testinghelpers.AssertActions(t, leaseActions, "create")
+				testinghelpers.AssertNoActions(t, clusterActions)
 			},
 		},
 		{
 			name:          "managed cluster stop update lease",
-			clusters:      []runtime.Object{newManagedCluster(newAcceptedCondtion(), newAvailableCondtion())},
-			clusterLeases: []runtime.Object{newClusterLease(now.Add(-5 * time.Minute))},
+			clusters:      []runtime.Object{testinghelpers.NewAvailableManagedCluster()},
+			clusterLeases: []runtime.Object{testinghelpers.NewManagedClusterLease(now.Add(-5 * time.Minute))},
 			validateActions: func(t *testing.T, leaseActions, clusterActions []clienttesting.Action) {
-				assertActions(t, clusterActions, "get", "update")
-				actual := clusterActions[1].(clienttesting.UpdateActionImpl).Object
 				expected := clusterv1.StatusCondition{
 					Type:    clusterv1.ManagedClusterConditionAvailable,
 					Status:  metav1.ConditionUnknown,
 					Reason:  "ManagedClusterLeaseUpdateStopped",
 					Message: "Registration agent stopped updating its lease within 5 minutes.",
 				}
-				assertCondition(t, actual, expected)
+				testinghelpers.AssertActions(t, clusterActions, "get", "update")
+				actual := clusterActions[1].(clienttesting.UpdateActionImpl).Object
+				testinghelpers.AssertManagedClusterCondition(t, actual.(*clusterv1.ManagedCluster).Status.Conditions, expected)
 			},
 		},
 		{
 			name:          "managed cluster is available",
-			clusters:      []runtime.Object{newManagedCluster(newAcceptedCondtion(), newAvailableCondtion())},
-			clusterLeases: []runtime.Object{newClusterLease(now)},
+			clusters:      []runtime.Object{testinghelpers.NewAvailableManagedCluster()},
+			clusterLeases: []runtime.Object{testinghelpers.NewManagedClusterLease(now)},
 			validateActions: func(t *testing.T, leaseActions, clusterActions []clienttesting.Action) {
-				assertActions(t, clusterActions)
+				testinghelpers.AssertNoActions(t, clusterActions)
 			},
 		},
 	}
@@ -96,87 +93,10 @@ func TestSync(t *testing.T) {
 				leaseLister:   leaseInformerFactory.Coordination().V1().Leases().Lister(),
 			}
 			syncErr := ctrl.sync(context.TODO(), testinghelpers.NewFakeSyncContext(t, ""))
-			if len(c.expectedErr) > 0 && syncErr == nil {
-				t.Errorf("expected %q error", c.expectedErr)
-				return
-			}
-			if len(c.expectedErr) > 0 && syncErr != nil && syncErr.Error() != c.expectedErr {
-				t.Errorf("expected %q error, got %q", c.expectedErr, syncErr.Error())
-				return
-			}
-			if len(c.expectedErr) == 0 && syncErr != nil {
+			if syncErr != nil {
 				t.Errorf("unexpected err: %v", syncErr)
 			}
 			c.validateActions(t, leaseClient.Actions(), clusterClient.Actions())
 		})
-	}
-}
-
-func assertActions(t *testing.T, actualActions []clienttesting.Action, expectedActions ...string) {
-	if len(actualActions) != len(expectedActions) {
-		t.Errorf("expected %d call but got: %#v", len(expectedActions), actualActions)
-	}
-	for i, expected := range expectedActions {
-		if actualActions[i].GetVerb() != expected {
-			t.Errorf("expected %s action but got: %#v", expected, actualActions[i])
-		}
-	}
-}
-
-func assertCondition(t *testing.T, actual runtime.Object, expectedCondition clusterv1.StatusCondition) {
-	managedCluster := actual.(*clusterv1.ManagedCluster)
-	cond := helpers.FindManagedClusterCondition(managedCluster.Status.Conditions, expectedCondition.Type)
-	if cond == nil {
-		t.Errorf("expected condition %s but got: %s", expectedCondition.Type, cond.Type)
-	}
-	if cond.Status != expectedCondition.Status {
-		t.Errorf("expected status %s but got: %s", expectedCondition.Status, cond.Status)
-	}
-	if cond.Reason != expectedCondition.Reason {
-		t.Errorf("expected reason %s but got: %s", expectedCondition.Reason, cond.Reason)
-	}
-	if cond.Message != expectedCondition.Message {
-		t.Errorf("expected message %s but got: %s", expectedCondition.Message, cond.Message)
-	}
-}
-
-func newManagedCluster(conditions ...clusterv1.StatusCondition) *clusterv1.ManagedCluster {
-	return &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "testmanagedcluster",
-		},
-		Status: clusterv1.ManagedClusterStatus{
-			Conditions: conditions,
-		},
-	}
-}
-
-func newAcceptedCondtion() clusterv1.StatusCondition {
-	return clusterv1.StatusCondition{
-		Type:    clusterv1.ManagedClusterConditionHubAccepted,
-		Status:  metav1.ConditionTrue,
-		Reason:  "HubClusterAdminAccepted",
-		Message: "Accepted by hub cluster admin",
-	}
-}
-
-func newAvailableCondtion() clusterv1.StatusCondition {
-	return clusterv1.StatusCondition{
-		Type:    clusterv1.ManagedClusterConditionAvailable,
-		Status:  metav1.ConditionTrue,
-		Reason:  "ManagedClusterAvailable",
-		Message: "Managed cluster is available",
-	}
-}
-
-func newClusterLease(renewTime time.Time) *coordv1.Lease {
-	return &coordv1.Lease{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cluster-lease-testmanagedcluster",
-			Namespace: "testmanagedcluster",
-		},
-		Spec: coordv1.LeaseSpec{
-			RenewTime: &metav1.MicroTime{Time: renewTime},
-		},
 	}
 }

--- a/pkg/hub/managedcluster/bindata/bindata.go
+++ b/pkg/hub/managedcluster/bindata/bindata.go
@@ -63,7 +63,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _pkgHubManagedclusterManifestsManagedclusterClusterroleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:open-cluster-management:managedcluster:{{ .ManagedClusterName }}
+  name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}
 rules:
 # Allow agent to rotate its certificate
 - apiGroups: ["certificates.k8s.io"]
@@ -102,11 +102,11 @@ func pkgHubManagedclusterManifestsManagedclusterClusterroleYaml() (*asset, error
 var _pkgHubManagedclusterManifestsManagedclusterClusterrolebindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:open-cluster-management:managedcluster:{{ .ManagedClusterName }}
+  name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:open-cluster-management:managedcluster:{{ .ManagedClusterName }}
+  name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}
 subjects:
 - kind: Group
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/hub/managedcluster/controller.go
+++ b/pkg/hub/managedcluster/controller.go
@@ -23,7 +23,6 @@ import (
 
 const (
 	manifestDir             = "pkg/hub/managedcluster"
-	clusterRolePrefix       = "system:open-cluster-management:managedcluster"
 	managedClusterFinalizer = "cluster.open-cluster-management.io/api-resource-cleanup"
 )
 

--- a/pkg/hub/managedcluster/controller_test.go
+++ b/pkg/hub/managedcluster/controller_test.go
@@ -2,92 +2,88 @@ package managedcluster
 
 import (
 	"context"
-	"reflect"
 	"testing"
-	"time"
 
 	clusterfake "github.com/open-cluster-management/api/client/cluster/clientset/versioned/fake"
+	v1 "github.com/open-cluster-management/api/cluster/v1"
+	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
+
+	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
-
-	v1 "github.com/open-cluster-management/api/cluster/v1"
-	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
-	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
 )
-
-const testManagedClusterName = "test_managed_cluster"
 
 func TestSyncManagedCluster(t *testing.T) {
 	cases := []struct {
 		name            string
 		startingObjects []runtime.Object
 		validateActions func(t *testing.T, actions []clienttesting.Action)
-		expectedErr     string
 	}{
 		{
 			name:            "sync a deleted spoke cluster",
 			startingObjects: []runtime.Object{},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Errorf("expected 1 call but got: %#v", actions)
-				}
-				assertAction(t, actions[0], "get")
+				testinghelpers.AssertActions(t, actions, "get")
 			},
 		},
 		{
 			name:            "create a new spoke cluster",
-			startingObjects: []runtime.Object{newManagedCluster()},
+			startingObjects: []runtime.Object{testinghelpers.NewManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 2 {
-					t.Errorf("expected 1 call but got: %#v", actions)
-				}
-				assertAction(t, actions[1], "update")
-				assertFinalizers(t, actions[1].(clienttesting.UpdateActionImpl).Object, []string{managedClusterFinalizer})
+				testinghelpers.AssertActions(t, actions, "get", "update")
+				managedCluster := (actions[1].(clienttesting.UpdateActionImpl).Object).(*v1.ManagedCluster)
+				testinghelpers.AssertFinalizers(t, managedCluster, []string{managedClusterFinalizer})
 			},
 		},
 		{
 			name:            "accept a spoke cluster",
-			startingObjects: []runtime.Object{newAcceptedManagedCluster([]string{managedClusterFinalizer})},
+			startingObjects: []runtime.Object{testinghelpers.NewAcceptingManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 3 {
-					t.Errorf("expected 3 call but got: %#v", actions)
+				expectedCondition := v1.StatusCondition{
+					Type:    v1.ManagedClusterConditionHubAccepted,
+					Status:  metav1.ConditionTrue,
+					Reason:  "HubClusterAdminAccepted",
+					Message: "Accepted by hub cluster admin",
 				}
-				assertAction(t, actions[2], "update")
-				assertCondition(t, actions[2].(clienttesting.UpdateActionImpl).Object, v1.ManagedClusterConditionHubAccepted, metav1.ConditionTrue)
+				testinghelpers.AssertActions(t, actions, "get", "get", "update")
+				actual := actions[2].(clienttesting.UpdateActionImpl).Object
+				managedCluster := actual.(*v1.ManagedCluster)
+				testinghelpers.AssertManagedClusterCondition(t, managedCluster.Status.Conditions, expectedCondition)
 			},
 		},
 		{
 			name:            "sync an accepted spoke cluster",
-			startingObjects: []runtime.Object{newAcceptedManagedClusterWithCondition()},
+			startingObjects: []runtime.Object{testinghelpers.NewAcceptedManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 2 {
-					t.Errorf("expected 2 call but got: %#v", actions)
-				}
-				assertAction(t, actions[1], "get")
+				testinghelpers.AssertActions(t, actions, "get", "get")
 			},
 		},
 		{
 			name:            "deny an accepted spoke cluster",
-			startingObjects: []runtime.Object{newDeniedManagedCluster()},
+			startingObjects: []runtime.Object{testinghelpers.NewDeniedManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 3 {
-					t.Errorf("expected 3 call but got: %#v", actions)
+				expectedCondition := v1.StatusCondition{
+					Type:    v1.ManagedClusterConditionHubAccepted,
+					Status:  metav1.ConditionFalse,
+					Reason:  "HubClusterAdminDenied",
+					Message: "Denied by hub cluster admin",
 				}
-				assertAction(t, actions[2], "update")
-				assertCondition(t, actions[2].(clienttesting.UpdateActionImpl).Object, v1.ManagedClusterConditionHubAccepted, metav1.ConditionFalse)
+				testinghelpers.AssertActions(t, actions, "get", "get", "update")
+				actual := actions[2].(clienttesting.UpdateActionImpl).Object
+				managedCluster := actual.(*v1.ManagedCluster)
+				testinghelpers.AssertManagedClusterCondition(t, managedCluster.Status.Conditions, expectedCondition)
 			},
 		},
 		{
 			name:            "delete a spoke cluster",
-			startingObjects: []runtime.Object{newDeletingManagedCluster()},
+			startingObjects: []runtime.Object{testinghelpers.NewDeletingManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 2 {
-					t.Errorf("expected 2 call but got: %#v", actions)
-				}
-				assertAction(t, actions[1], "update")
-				assertFinalizers(t, actions[1].(clienttesting.UpdateActionImpl).Object, []string{})
+				testinghelpers.AssertActions(t, actions, "get", "update")
+				managedCluster := (actions[1].(clienttesting.UpdateActionImpl).Object).(*v1.ManagedCluster)
+				testinghelpers.AssertFinalizers(t, managedCluster, []string{})
 			},
 		},
 	}
@@ -98,93 +94,12 @@ func TestSyncManagedCluster(t *testing.T) {
 			kubeClient := kubefake.NewSimpleClientset()
 
 			ctrl := managedClusterController{kubeClient, clusterClient, eventstesting.NewTestingEventRecorder(t)}
-			syncErr := ctrl.sync(context.TODO(), testinghelpers.NewFakeSyncContext(t, testManagedClusterName))
-			if len(c.expectedErr) > 0 && syncErr == nil {
-				t.Errorf("expected %q error", c.expectedErr)
-				return
-			}
-			if len(c.expectedErr) > 0 && syncErr != nil && syncErr.Error() != c.expectedErr {
-				t.Errorf("expected %q error, got %q", c.expectedErr, syncErr.Error())
-				return
-			}
+			syncErr := ctrl.sync(context.TODO(), testinghelpers.NewFakeSyncContext(t, testinghelpers.TestManagedClusterName))
 			if syncErr != nil {
 				t.Errorf("unexpected err: %v", syncErr)
 			}
 
 			c.validateActions(t, clusterClient.Actions())
 		})
-	}
-}
-
-func assertAction(t *testing.T, actual clienttesting.Action, expected string) {
-	if actual.GetVerb() != expected {
-		t.Errorf("expected %s action but got: %#v", expected, actual)
-	}
-}
-
-func assertFinalizers(t *testing.T, actual runtime.Object, expected []string) {
-	managedCluster := actual.(*v1.ManagedCluster)
-	if !reflect.DeepEqual(managedCluster.Finalizers, expected) {
-		t.Errorf("expected %#v but got %#v", expected, managedCluster.Finalizers)
-	}
-}
-
-func assertCondition(t *testing.T, actual runtime.Object, expectedCondition string, expectedStatus metav1.ConditionStatus) {
-	managedCluster := actual.(*v1.ManagedCluster)
-	conditions := managedCluster.Status.Conditions
-	if len(conditions) != 1 {
-		t.Errorf("expected 1 condition but got: %#v", conditions)
-	}
-	condition := conditions[0]
-	if condition.Type != expectedCondition {
-		t.Errorf("expected %s but got: %s", expectedCondition, condition.Type)
-	}
-	if condition.Status != expectedStatus {
-		t.Errorf("expected %s but got: %s", expectedStatus, condition.Status)
-	}
-}
-
-func newManagedCluster() *v1.ManagedCluster {
-	return &v1.ManagedCluster{ObjectMeta: metav1.ObjectMeta{Name: testManagedClusterName}}
-}
-
-func newAcceptedManagedCluster(finalizers []string) *v1.ManagedCluster {
-	return &v1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       testManagedClusterName,
-			Finalizers: finalizers,
-		},
-		Spec: v1.ManagedClusterSpec{HubAcceptsClient: true},
-	}
-}
-
-func newAcceptedManagedClusterWithCondition() *v1.ManagedCluster {
-	spokeCluster := newAcceptedManagedCluster([]string{managedClusterFinalizer})
-	spokeCluster.Finalizers = append(spokeCluster.Finalizers, managedClusterFinalizer)
-	spokeCluster.Status.Conditions = append(spokeCluster.Status.Conditions, v1.StatusCondition{
-		Type:               v1.ManagedClusterConditionHubAccepted,
-		Status:             metav1.ConditionTrue,
-		Reason:             "HubClusterAdminAccepted",
-		Message:            "Accepted by hub cluster admin",
-		LastTransitionTime: metav1.Time{Time: metav1.Now().Add(-10 * time.Second)},
-	})
-	return spokeCluster
-}
-
-func newDeniedManagedCluster() *v1.ManagedCluster {
-	spokeCluster := newAcceptedManagedClusterWithCondition()
-	spokeCluster.Spec.HubAcceptsClient = false
-	return spokeCluster
-}
-
-func newDeletingManagedCluster() *v1.ManagedCluster {
-	now := metav1.Now()
-	return &v1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              testManagedClusterName,
-			DeletionTimestamp: &now,
-			Finalizers:        []string{managedClusterFinalizer},
-		},
-		Spec: v1.ManagedClusterSpec{HubAcceptsClient: true},
 	}
 }

--- a/pkg/hub/managedcluster/manifests/managedcluster-clusterrole.yaml
+++ b/pkg/hub/managedcluster/manifests/managedcluster-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: system:open-cluster-management:managedcluster:{{ .ManagedClusterName }}
+  name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}
 rules:
 # Allow agent to rotate its certificate
 - apiGroups: ["certificates.k8s.io"]

--- a/pkg/hub/managedcluster/manifests/managedcluster-clusterrolebinding.yaml
+++ b/pkg/hub/managedcluster/manifests/managedcluster-clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:open-cluster-management:managedcluster:{{ .ManagedClusterName }}
+  name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:open-cluster-management:managedcluster:{{ .ManagedClusterName }}
+  name: open-cluster-management:managedcluster:{{ .ManagedClusterName }}
 subjects:
 - kind: Group
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/hub/manager.go
+++ b/pkg/hub/manager.go
@@ -2,13 +2,10 @@ package hub
 
 import (
 	"context"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
 
 	clusterv1client "github.com/open-cluster-management/api/client/cluster/clientset/versioned"
 	clusterv1informers "github.com/open-cluster-management/api/client/cluster/informers/externalversions"
@@ -85,21 +82,7 @@ func RunControllerManager(ctx context.Context, controllerContext *controllercmd.
 	go leaseController.Run(ctx, 1)
 	go rbacFinalizerController.Run(ctx, 1)
 
-	//Add Custom Metrics
-	//make sure its a go func call else it will block
-	enableMetric := false
-	val, exists := os.LookupEnv("METRIC_ENABLE")
-	if exists {
-		enableMetric, err = strconv.ParseBool(val)
-		if err != nil {
-			klog.Warning("Error parsing env METRIC_ENABLE.  Expected a bool.  Original error: ", err)
-			klog.Info("Falling back on default FALSE; Metric collection will be disabled")
-		}
-	}
-
-	if enableMetric {
-		go custommetrics.MetricStart(8890)
-	}
+	go custommetrics.MetricStart()
 
 	<-ctx.Done()
 	return nil

--- a/pkg/hub/manager.go
+++ b/pkg/hub/manager.go
@@ -82,7 +82,7 @@ func RunControllerManager(ctx context.Context, controllerContext *controllercmd.
 	go leaseController.Run(ctx, 1)
 	go rbacFinalizerController.Run(ctx, 1)
 
-	go custommetrics.MetricStart()
+	go custommetrics.MetricStart(controllerContext)
 
 	<-ctx.Done()
 	return nil

--- a/pkg/hub/rbacfinalizerdeletion/controller.go
+++ b/pkg/hub/rbacfinalizerdeletion/controller.go
@@ -8,8 +8,10 @@ import (
 	clusterv1listers "github.com/open-cluster-management/api/client/cluster/listers/cluster/v1"
 	worklister "github.com/open-cluster-management/api/client/work/listers/work/v1"
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
+
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/spoke/hubclientcert/certificate_test.go
+++ b/pkg/spoke/hubclientcert/certificate_test.go
@@ -1,392 +1,143 @@
 package hubclientcert
 
 import (
-	"crypto"
-	"crypto/rand"
-	cryptorand "crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"errors"
-	"math"
-	"math/big"
 	"testing"
 	"time"
 
+	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
+
 	certificates "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/keyutil"
 )
 
-func newCertKey(commonName string, duration time.Duration) ([]byte, []byte, error) {
-	signingKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	signingCert, err := certutil.NewSelfSignedCACert(certutil.Config{CommonName: "open-cluster-management.io"}, signingKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	key, err := rsa.GenerateKey(cryptorand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	cert, err := newSignedCert(
-		certutil.Config{
-			CommonName: commonName,
-			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+func TestCSRApproved(t *testing.T) {
+	cases := []struct {
+		name        string
+		csr         *certificates.CertificateSigningRequest
+		csrApproved bool
+	}{
+		{
+			name: "pending csr",
+			csr:  testinghelpers.NewCSR(testinghelpers.CSRHolder{}),
 		},
-		key, signingCert, signingKey, duration,
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return encodePrivateKeyPEM(key), encodeCertPEM(cert), nil
-}
-
-// encodePrivateKeyPEM returns PEM-encoded private key data
-func encodePrivateKeyPEM(key *rsa.PrivateKey) []byte {
-	block := pem.Block{
-		Type:  keyutil.RSAPrivateKeyBlockType,
-		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	}
-	return pem.EncodeToMemory(&block)
-}
-
-// encodeCertPEM returns PEM-encoded certificate data
-func encodeCertPEM(cert *x509.Certificate) []byte {
-	block := pem.Block{
-		Type:  certutil.CertificateBlockType,
-		Bytes: cert.Raw,
-	}
-	return pem.EncodeToMemory(&block)
-}
-
-// newSignedCert creates a signed certificate using the given CA certificate and key
-func newSignedCert(cfg certutil.Config, key crypto.Signer, caCert *x509.Certificate, caKey crypto.Signer, duration time.Duration) (*x509.Certificate, error) {
-	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
-	if err != nil {
-		return nil, err
-	}
-	if len(cfg.CommonName) == 0 {
-		return nil, errors.New("must specify a CommonName")
-	}
-	if len(cfg.Usages) == 0 {
-		return nil, errors.New("must specify at least one ExtKeyUsage")
-	}
-
-	certTmpl := x509.Certificate{
-		Subject: pkix.Name{
-			CommonName:   cfg.CommonName,
-			Organization: cfg.Organization,
+		{
+			name: "denied csr",
+			csr:  testinghelpers.NewDeniedCSR(testinghelpers.CSRHolder{}),
 		},
-		DNSNames:     cfg.AltNames.DNSNames,
-		IPAddresses:  cfg.AltNames.IPs,
-		SerialNumber: serial,
-		NotBefore:    caCert.NotBefore,
-		NotAfter:     time.Now().Add(duration).UTC(),
-		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  cfg.Usages,
-	}
-	certDERBytes, err := x509.CreateCertificate(cryptorand.Reader, &certTmpl, caCert, key.Public(), caKey)
-	if err != nil {
-		return nil, err
-	}
-	return x509.ParseCertificate(certDERBytes)
-}
-
-func newKubeconfig(key, cert []byte) clientcmdapi.Config {
-	var clientKey, clientCertificate string
-	var clientKeyData, clientCertificateData []byte
-	if key != nil {
-		clientKeyData = key
-	} else {
-		clientKey = "tls.key"
-	}
-	if cert != nil {
-		clientCertificateData = cert
-	} else {
-		clientCertificate = "tls.crt"
-	}
-
-	kubeconfig := clientcmdapi.Config{
-		// Define a cluster stanza based on the bootstrap kubeconfig.
-		Clusters: map[string]*clientcmdapi.Cluster{"default-cluster": {
-			Server:                "https://127.0.0.1:6001",
-			InsecureSkipTLSVerify: true,
-		}},
-		// Define auth based on the obtained client cert.
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{"default-auth": {
-			ClientCertificate:     clientCertificate,
-			ClientCertificateData: clientCertificateData,
-			ClientKey:             clientKey,
-			ClientKeyData:         clientKeyData,
-		}},
-		// Define a context that connects the auth info and cluster, and set it as the default
-		Contexts: map[string]*clientcmdapi.Context{"default-context": {
-			Cluster:   "default-cluster",
-			AuthInfo:  "default-auth",
-			Namespace: "default",
-		}},
-		CurrentContext: "default-context",
-	}
-
-	return kubeconfig
-}
-
-func TestIsCSRApprovedWithPendingCSR(t *testing.T) {
-	csr := &certificates.CertificateSigningRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "csr-",
+		{
+			name:        "approved csr",
+			csr:         testinghelpers.NewApprovedCSR(testinghelpers.CSRHolder{}),
+			csrApproved: true,
 		},
-		Spec: certificates.CertificateSigningRequestSpec{},
 	}
-
-	if isCSRApproved(csr) {
-		t.Error("csr is not approved")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			csrApproved := isCSRApproved(c.csr)
+			if csrApproved != c.csrApproved {
+				t.Errorf("expected %t, but got %t", c.csrApproved, csrApproved)
+			}
+		})
 	}
 }
 
-func TestIsCSRApprovedWithApprovedCSR(t *testing.T) {
-	csr := &certificates.CertificateSigningRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "csr-",
+func TestValidKubeconfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		secret  *corev1.Secret
+		isValid bool
+	}{
+		{
+			name:   "no data",
+			secret: testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, nil),
 		},
-		Spec: certificates.CertificateSigningRequestSpec{},
-		Status: certificates.CertificateSigningRequestStatus{
-			Conditions: []certificates.CertificateSigningRequestCondition{
-				{
-					Type: certificates.CertificateApproved,
-				},
-			},
+		{
+			name:   "no kubeconfig",
+			secret: testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, map[string][]byte{}),
+		},
+		{
+			name: "no key",
+			secret: testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, map[string][]byte{
+				KubeconfigFile: testinghelpers.NewKubeconfig(nil, nil),
+			}),
+		},
+		{
+			name: "no cert",
+			secret: testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", &testinghelpers.TestCert{Key: []byte("key")}, map[string][]byte{
+				KubeconfigFile: testinghelpers.NewKubeconfig(nil, nil),
+			}),
+		},
+		{
+			name: "bad cert",
+			secret: testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", &testinghelpers.TestCert{Key: []byte("key"), Cert: []byte("bad cert")}, map[string][]byte{
+				KubeconfigFile: testinghelpers.NewKubeconfig(nil, nil),
+			}),
+		},
+		{
+			name: "valid hub config",
+			secret: testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", testinghelpers.NewTestCert("test", 60*time.Second), map[string][]byte{
+				KubeconfigFile: testinghelpers.NewKubeconfig(nil, nil),
+			}),
+			isValid: true,
 		},
 	}
-
-	if !isCSRApproved(csr) {
-		t.Error("csr is approved")
-	}
-}
-
-func TestIsCSRApprovedWithDeniedCSR(t *testing.T) {
-	csr := &certificates.CertificateSigningRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "csr-",
-		},
-		Spec: certificates.CertificateSigningRequestSpec{},
-		Status: certificates.CertificateSigningRequestStatus{
-			Conditions: []certificates.CertificateSigningRequestCondition{
-				{
-					Type: certificates.CertificateApproved,
-				},
-				{
-					Type: certificates.CertificateDenied,
-				},
-			},
-		},
-	}
-
-	if isCSRApproved(csr) {
-		t.Error("csr is denied")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			isValid := hasValidKubeconfig(c.secret)
+			if isValid != c.isValid {
+				t.Errorf("expected %t, but got %t", c.isValid, isValid)
+			}
+		})
 	}
 }
 
 func TestGetCertValidityPeriod(t *testing.T) {
-	_, cert, err := newCertKey("cluster0", 10*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "secret",
+	certs := []byte{}
+	certs = append(certs, testinghelpers.NewTestCert("cluster0", 10*time.Second).Cert...)
+	secondCert := testinghelpers.NewTestCert("cluster0", 5*time.Second).Cert
+	certs = append(certs, secondCert...)
+	expectedCerts, _ := certutil.ParseCertsPEM(secondCert)
+	cases := []struct {
+		name         string
+		secret       *corev1.Secret
+		expectedCert *x509.Certificate
+		expectedErr  string
+	}{
+		{
+			name:        "no data",
+			secret:      testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, nil),
+			expectedErr: "no client certificate found in secret \"testns/testsecret\"",
 		},
-		Data: map[string][]byte{
-			TLSCertFile: cert,
+		{
+			name:        "no cert",
+			secret:      testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", nil, map[string][]byte{}),
+			expectedErr: "no client certificate found in secret \"testns/testsecret\"",
 		},
-	}
-
-	notBefore, notAfter, err := getCertValidityPeriod(secret)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if notBefore == nil {
-		t.Error("notBefore should not be nil")
-	}
-
-	if notAfter == nil {
-		t.Error("notAfter should not be nil")
-	}
-}
-
-func TestIsCertificateValid(t *testing.T) {
-	_, cert, err := newCertKey("cluster0", 100*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	valid, err := IsCertificateValid(cert)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if !valid {
-		t.Error("cert is valid")
-	}
-}
-
-func TestIsCertificateValidWithExpiredCert(t *testing.T) {
-	_, cert, err := newCertKey("cluster0", -3*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	valid, err := IsCertificateValid(cert)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if valid {
-		t.Error("cert is expired")
-	}
-}
-
-func TestHasValidKubeconfig(t *testing.T) {
-	kubeconfigData, err := clientcmd.Write(newKubeconfig(nil, nil))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	key, cert, err := newCertKey("cluster0", 100*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "secret",
+		{
+			name:        "bad cert",
+			secret:      testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", &testinghelpers.TestCert{Cert: []byte("bad cert")}, map[string][]byte{}),
+			expectedErr: "unable to parse TLS certificates: data does not contain any valid RSA or ECDSA certificates",
 		},
-		Data: map[string][]byte{
-			KubeconfigFile: kubeconfigData,
-			TLSCertFile:    cert,
-			TLSKeyFile:     key,
+		{
+			name:         "valid cert",
+			secret:       testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "", &testinghelpers.TestCert{Cert: certs}, map[string][]byte{}),
+			expectedCert: expectedCerts[0],
 		},
 	}
-
-	if !hasValidKubeconfig(secret) {
-		t.Error("kubeconfig is valid")
-	}
-}
-
-func TestHasValidKubeconfigWithExpiredCert(t *testing.T) {
-	kubeconfigData, err := clientcmd.Write(newKubeconfig(nil, nil))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	key, cert, err := newCertKey("cluster0", -3*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "secret",
-		},
-		Data: map[string][]byte{
-			KubeconfigFile: kubeconfigData,
-			TLSCertFile:    cert,
-			TLSKeyFile:     key,
-		},
-	}
-
-	if hasValidKubeconfig(secret) {
-		t.Error("kubeconfig is invalid")
-	}
-}
-
-func TestHasValidKubeconfigWithoutKey(t *testing.T) {
-	kubeconfigData, err := clientcmd.Write(newKubeconfig(nil, nil))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	_, cert, err := newCertKey("cluster0", 100*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "secret",
-		},
-		Data: map[string][]byte{
-			KubeconfigFile: kubeconfigData,
-			TLSCertFile:    cert,
-		},
-	}
-
-	if hasValidKubeconfig(secret) {
-		t.Error("kubeconfig is invalid")
-	}
-}
-
-func TestHasValidKubeconfigWithoutCert(t *testing.T) {
-	kubeconfigData, err := clientcmd.Write(newKubeconfig(nil, nil))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	key, _, err := newCertKey("cluster0", 100*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "secret",
-		},
-		Data: map[string][]byte{
-			KubeconfigFile: kubeconfigData,
-			TLSKeyFile:     key,
-		},
-	}
-
-	if hasValidKubeconfig(secret) {
-		t.Error("kubeconfig is invalid")
-	}
-}
-
-func TestHasValidKubeconfigWithoutKubeconfig(t *testing.T) {
-	key, cert, err := newCertKey("cluster0", 100*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "secret",
-		},
-		Data: map[string][]byte{
-			TLSCertFile: cert,
-			TLSKeyFile:  key,
-		},
-	}
-
-	if hasValidKubeconfig(secret) {
-		t.Error("kubeconfig is invalid")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			notBefore, notAfter, err := getCertValidityPeriod(c.secret)
+			testinghelpers.AssertError(t, err, c.expectedErr)
+			if c.expectedCert == nil {
+				return
+			}
+			if !c.expectedCert.NotBefore.Equal(*notBefore) {
+				t.Errorf("expect %v, but got %v", expectedCerts[0].NotBefore, *notBefore)
+			}
+			if !c.expectedCert.NotAfter.Equal(*notAfter) {
+				t.Errorf("expect %v, but got %v", expectedCerts[0].NotAfter, *notAfter)
+			}
+		})
 	}
 }

--- a/pkg/spoke/hubclientcert/controller.go
+++ b/pkg/spoke/hubclientcert/controller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
+
 	certificates "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/spoke/hubclientcert/controller_test.go
+++ b/pkg/spoke/hubclientcert/controller_test.go
@@ -3,405 +3,186 @@ package hubclientcert
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
-	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/operator/events"
+	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
+
 	certificates "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/keyutil"
 )
 
-func newSecret(namespace, name, resourceVersion string, data map[string][]byte) *corev1.Secret {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:       namespace,
-			Name:            name,
-			ResourceVersion: resourceVersion,
-		},
-		Data: data,
-	}
+const (
+	testNamespace  = "testns"
+	testAgentName  = "testagent"
+	testSecretName = "testsecret"
+	testCSRName    = "testcsr"
+)
 
-	return secret
-}
+var commonName = fmt.Sprintf("%s%s:%s", subjectPrefix, testinghelpers.TestManagedClusterName, testAgentName)
 
-func TestSyncCSR(t *testing.T) {
-	secretNamespace := "default"
-	secretName := "secret"
-	secret := newSecret(secretNamespace, secretName, "", nil)
-
-	key, cert, err := newCertKey("cluster0", 10*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	csrName := "csr1"
-	csr := &certificates.CertificateSigningRequest{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: csrName,
-		},
-		Spec: certificates.CertificateSigningRequestSpec{},
-		Status: certificates.CertificateSigningRequestStatus{
-			Conditions: []certificates.CertificateSigningRequestCondition{
-				{
-					Type: certificates.CertificateApproved,
-				},
+func TestSync(t *testing.T) {
+	cases := []struct {
+		name            string
+		secrets         []runtime.Object
+		approvedCSRCert *testinghelpers.TestCert
+		keyDataExpected bool
+		csrNameExpected bool
+		validateActions func(t *testing.T, hubActions, agentActions []clienttesting.Action)
+	}{
+		{
+			name:            "agent bootstrap",
+			secrets:         []runtime.Object{},
+			keyDataExpected: true,
+			csrNameExpected: true,
+			validateActions: func(t *testing.T, hubActions, agentActions []clienttesting.Action) {
+				testinghelpers.AssertActions(t, hubActions, "create")
+				actual := hubActions[0].(clienttesting.CreateActionImpl).Object
+				if _, ok := actual.(*certificates.CertificateSigningRequest); !ok {
+					t.Errorf("expected csr was created, but failed")
+				}
+				expectedSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      testSecretName,
+					},
+					Data: map[string][]byte{
+						ClusterNameFile: []byte(testinghelpers.TestManagedClusterName),
+						AgentNameFile:   []byte(testAgentName),
+					},
+				}
+				testinghelpers.AssertActions(t, agentActions, "create")
+				actualSecret := agentActions[0].(clienttesting.CreateActionImpl).Object
+				if !reflect.DeepEqual(expectedSecret, actualSecret) {
+					t.Errorf("expected secret %v, but got %v", expectedSecret, actualSecret)
+				}
 			},
-			Certificate: cert,
+		},
+		{
+			name: "syc csr after bootstrap",
+			secrets: []runtime.Object{
+				testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "1", nil, map[string][]byte{
+					ClusterNameFile: []byte(testinghelpers.TestManagedClusterName),
+					AgentNameFile:   []byte(testAgentName),
+				},
+				),
+			},
+			approvedCSRCert: testinghelpers.NewTestCert(testinghelpers.TestManagedClusterName, 10*time.Second),
+			validateActions: func(t *testing.T, hubActions, agentActions []clienttesting.Action) {
+				testinghelpers.AssertActions(t, hubActions, "get")
+				testinghelpers.AssertActions(t, agentActions, "update")
+				actual := agentActions[0].(clienttesting.UpdateActionImpl).Object
+				if !hasValidKubeconfig(actual.(*corev1.Secret)) {
+					t.Error("kubeconfig secret is invalid")
+				}
+			},
+		},
+		{
+			name: "sync a valid hub kubeconfig secret",
+			secrets: []runtime.Object{
+				testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "1", testinghelpers.NewTestCert(commonName, 100*time.Second), map[string][]byte{
+					ClusterNameFile: []byte(testinghelpers.TestManagedClusterName),
+					AgentNameFile:   []byte(testAgentName),
+					KubeconfigFile:  testinghelpers.NewKubeconfig(nil, nil),
+				}),
+			},
+			validateActions: func(t *testing.T, hubActions, agentActions []clienttesting.Action) {
+				testinghelpers.AssertNoActions(t, hubActions)
+				testinghelpers.AssertNoActions(t, agentActions)
+			},
+		},
+		{
+			name: "sync an expiring hub kubeconfig secret",
+			secrets: []runtime.Object{
+				testinghelpers.NewHubKubeconfigSecret(testNamespace, testSecretName, "1", testinghelpers.NewTestCert(commonName, -3*time.Second), map[string][]byte{
+					ClusterNameFile: []byte(testinghelpers.TestManagedClusterName),
+					AgentNameFile:   []byte(testAgentName),
+					KubeconfigFile:  testinghelpers.NewKubeconfig(nil, nil),
+				}),
+			},
+			keyDataExpected: true,
+			csrNameExpected: true,
+			validateActions: func(t *testing.T, hubActions, agentActions []clienttesting.Action) {
+				testinghelpers.AssertActions(t, hubActions, "create")
+				actual := hubActions[0].(clienttesting.CreateActionImpl).Object
+				if _, ok := actual.(*certificates.CertificateSigningRequest); !ok {
+					t.Errorf("expected csr was created, but failed")
+				}
+				testinghelpers.AssertNoActions(t, agentActions)
+			},
 		},
 	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			csrs := []runtime.Object{}
+			if c.approvedCSRCert != nil {
+				csr := testinghelpers.NewApprovedCSR(testinghelpers.CSRHolder{Name: testCSRName})
+				csr.Status.Certificate = c.approvedCSRCert.Cert
+				csrs = append(csrs, csr)
+			}
+			hubKubeClient := kubefake.NewSimpleClientset(csrs...)
+			// GenerateName is not working for fake clent, we set the name with prepend reactor
+			hubKubeClient.PrependReactor(
+				"create",
+				"certificatesigningrequests",
+				func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, testinghelpers.NewCSR(testinghelpers.CSRHolder{Name: testCSRName}), nil
+				},
+			)
+			hubInformerFactory := informers.NewSharedInformerFactory(hubKubeClient, 3*time.Minute)
 
-	fakeKubeClient := kubefake.NewSimpleClientset(csr, secret)
-	csrInformer := informers.NewSharedInformerFactory(fakeKubeClient,
-		3*time.Minute).Certificates().V1beta1().CertificateSigningRequests()
+			agentKubeClient := kubefake.NewSimpleClientset(c.secrets...)
+			agentInformerFactory := informers.NewSharedInformerFactory(agentKubeClient, 3*time.Minute)
+			secretStore := agentInformerFactory.Core().V1().Secrets().Informer().GetStore()
+			for _, secret := range c.secrets {
+				secretStore.Add(secret)
+			}
 
-	// create csr informer/lister
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go csrInformer.Informer().Run(ctx.Done())
-	if ok := cache.WaitForCacheSync(ctx.Done(), csrInformer.Informer().HasSynced); !ok {
-		t.Error("failed to wait for kubernetes caches to sync")
-	}
+			controller := &ClientCertForHubController{
+				clusterName:                  testinghelpers.TestManagedClusterName,
+				agentName:                    testAgentName,
+				hubKubeconfigSecretNamespace: testNamespace,
+				hubKubeconfigSecretName:      testSecretName,
+				hubCSRLister:                 hubInformerFactory.Certificates().V1beta1().CertificateSigningRequests().Lister(),
+				hubCSRClient:                 hubKubeClient.CertificatesV1beta1().CertificateSigningRequests(),
+				spokeSecretLister:            agentInformerFactory.Core().V1().Secrets().Lister(),
+				spokeCoreClient:              agentKubeClient.CoreV1(),
+			}
 
-	// create a fake client config as template
-	kubeconfigData, err := clientcmd.Write(newKubeconfig(key, cert))
-	clientConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+			if c.approvedCSRCert != nil {
+				controller.csrName = testCSRName
+				controller.keyData = c.approvedCSRCert.Key
+				kubeconfig := testinghelpers.NewKubeconfig(c.approvedCSRCert.Key, c.approvedCSRCert.Cert)
+				clientConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				controller.hubClientConfig = clientConfig
+			}
 
-	controller := &ClientCertForHubController{
-		csrName:         csrName,
-		keyData:         key,
-		hubCSRLister:    csrInformer.Lister(),
-		hubClientConfig: clientConfig,
-		hubCSRClient:    fakeKubeClient.CertificatesV1beta1().CertificateSigningRequests(),
-	}
-	newSecretConfig, err := controller.syncCSR(secret)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if newSecretConfig == nil {
-		t.Error("secret should be changed")
-	}
+			err := controller.sync(context.TODO(), testinghelpers.NewFakeSyncContext(t, ""))
+			if err != nil {
+				t.Errorf("unexpected error %v", err)
+			}
 
-	// check if csrName/keyData are cleared
-	if controller.csrName != "" {
-		t.Error("controller.csrName should be empty")
-	}
-	if controller.keyData != nil {
-		t.Error("controller.keyData should be nil")
-	}
+			hasKeyData := controller.keyData != nil
+			if c.keyDataExpected != hasKeyData {
+				t.Error("controller.keyData should be set")
+			}
 
-	// validate the kubeconfig in secret
-	secret.Data = newSecretConfig
-	if !hasValidKubeconfig(secret) {
-		t.Error("kubeconfig should be valid")
-	}
-}
+			hasCSRName := controller.csrName != ""
+			if c.csrNameExpected != hasCSRName {
+				t.Error("controller.csrName should be set")
+			}
 
-// test bootstrap
-func TestSyncWithoutHubKubeconfigSecret(t *testing.T) {
-	secretNamespace := "default"
-	secretName := "secret"
-
-	clusterName := "cluster0"
-	agentName := "agent0"
-	fakeKubeClient := kubefake.NewSimpleClientset()
-
-	// create secret informer/lister
-	secretInformer := informers.NewSharedInformerFactory(fakeKubeClient,
-		3*time.Minute).Core().V1().Secrets()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go secretInformer.Informer().Run(ctx.Done())
-	if ok := cache.WaitForCacheSync(ctx.Done(), secretInformer.Informer().HasSynced); !ok {
-		t.Error("failed to wait for kubernetes caches to sync")
-	}
-
-	controller := &ClientCertForHubController{
-		clusterName:                  clusterName,
-		agentName:                    agentName,
-		hubKubeconfigSecretNamespace: secretNamespace,
-		hubKubeconfigSecretName:      secretName,
-		spokeCoreClient:              fakeKubeClient.CoreV1(),
-		hubCSRClient:                 fakeKubeClient.CertificatesV1beta1().CertificateSigningRequests(),
-		spokeSecretLister:            secretInformer.Lister(),
-	}
-
-	eventRecorder := events.NewInMemoryRecorder("")
-	syncContext := factory.NewSyncContext("", eventRecorder)
-	err := controller.sync(nil, syncContext)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secret, err := fakeKubeClient.CoreV1().Secrets(secretNamespace).Get(context.Background(), secretName, metav1.GetOptions{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	// check if cluster/agent name are stored into secret
-	if len(secret.Data) == 0 {
-		t.Errorf("secret should have data stored")
-	}
-	if string(secret.Data[ClusterNameFile]) != clusterName {
-		t.Errorf("expected cluster name %q but got: %s", clusterName, string(secret.Data[ClusterNameFile]))
-	}
-	if string(secret.Data[AgentNameFile]) != agentName {
-		t.Errorf("expected agent name %q but got: %s", agentName, string(secret.Data[AgentNameFile]))
-	}
-
-	// check if there is new csr created
-	csrs, err := fakeKubeClient.CertificatesV1beta1().CertificateSigningRequests().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if len(csrs.Items) != 1 {
-		t.Errorf("expect 1 csr created, but got: %d", len(csrs.Items))
-	}
-
-	// check if csrName/keyData are set. Since GenerateName is not working for fake clent, check keyData only
-	if controller.keyData == nil {
-		t.Error("controller.keyData should be set")
-	}
-}
-
-func TestSyncWithValidKubeconfig(t *testing.T) {
-	kubeconfigData, err := clientcmd.Write(newKubeconfig(nil, nil))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	clusterName := "cluster0"
-	agentName := "agent0"
-	key, cert, err := newCertKey(fmt.Sprintf("%s%s:%s", subjectPrefix, clusterName, agentName), 100*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secretNamespace := "default"
-	secretName := "secret"
-	secret := newSecret(secretNamespace, secretName, "1", map[string][]byte{
-		KubeconfigFile: kubeconfigData,
-		TLSCertFile:    cert,
-		TLSKeyFile:     key,
-	})
-
-	fakeKubeClient := kubefake.NewSimpleClientset(secret)
-
-	// create secret informer/lister
-	secretInformer := informers.NewSharedInformerFactory(fakeKubeClient,
-		3*time.Minute).Core().V1().Secrets()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go secretInformer.Informer().Run(ctx.Done())
-	if ok := cache.WaitForCacheSync(ctx.Done(), secretInformer.Informer().HasSynced); !ok {
-		t.Error("failed to wait for kubernetes caches to sync")
-	}
-
-	controller := &ClientCertForHubController{
-		clusterName:                  clusterName,
-		agentName:                    agentName,
-		hubKubeconfigSecretNamespace: secretNamespace,
-		hubKubeconfigSecretName:      secretName,
-		spokeCoreClient:              fakeKubeClient.CoreV1(),
-		hubCSRClient:                 fakeKubeClient.CertificatesV1beta1().CertificateSigningRequests(),
-		spokeSecretLister:            secretInformer.Lister(),
-	}
-
-	eventRecorder := events.NewInMemoryRecorder("")
-	syncContext := factory.NewSyncContext("", eventRecorder)
-	err = controller.sync(nil, syncContext)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	// check if there is any csr created
-	csrs, err := fakeKubeClient.CertificatesV1beta1().CertificateSigningRequests().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if len(csrs.Items) != 0 {
-		t.Errorf("expect 0 csr created, but got: %d", len(csrs.Items))
-	}
-
-	// check if csrName/keyData are unset
-	if controller.csrName != "" {
-		t.Error("controller.csrName should be empty")
-	}
-	if controller.keyData != nil {
-		t.Error("controller.keyData should be nil")
-	}
-}
-
-// test cert rotation
-func TestSyncWithExpiringCert(t *testing.T) {
-	kubeconfigData, err := clientcmd.Write(newKubeconfig(nil, nil))
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	clusterName := "cluster0"
-	agentName := "agent0"
-
-	key, cert, err := newCertKey(fmt.Sprintf("%s%s:%s", subjectPrefix, clusterName, agentName), -3*time.Second)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secretNamespace := "default"
-	secretName := "secret"
-	secret := newSecret(secretNamespace, secretName, "1", map[string][]byte{
-		KubeconfigFile: kubeconfigData,
-		TLSCertFile:    cert,
-		TLSKeyFile:     key,
-	})
-
-	fakeKubeClient := kubefake.NewSimpleClientset(secret)
-
-	// create secret informer/lister
-	secretInformer := informers.NewSharedInformerFactory(fakeKubeClient,
-		3*time.Minute).Core().V1().Secrets()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go secretInformer.Informer().Run(ctx.Done())
-	if ok := cache.WaitForCacheSync(ctx.Done(), secretInformer.Informer().HasSynced); !ok {
-		t.Error("failed to wait for kubernetes caches to sync")
-	}
-
-	controller := &ClientCertForHubController{
-		clusterName:                  clusterName,
-		agentName:                    agentName,
-		hubKubeconfigSecretNamespace: secretNamespace,
-		hubKubeconfigSecretName:      secretName,
-		spokeCoreClient:              fakeKubeClient.CoreV1(),
-		hubCSRClient:                 fakeKubeClient.CertificatesV1beta1().CertificateSigningRequests(),
-		spokeSecretLister:            secretInformer.Lister(),
-	}
-
-	eventRecorder := events.NewInMemoryRecorder("")
-	syncContext := factory.NewSyncContext("", eventRecorder)
-	err = controller.sync(nil, syncContext)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	// check if there is any csr created
-	csrs, err := fakeKubeClient.CertificatesV1beta1().CertificateSigningRequests().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	if len(csrs.Items) != 1 {
-		t.Errorf("expect 1 csr created, but got: %d", len(csrs.Items))
-	}
-
-	// check if csrName/keyData are set. Since GenerateName is not working for fake clent, check keyData only
-	if controller.keyData == nil {
-		t.Error("controller.keyData should be set")
-	}
-}
-
-func TestCreateCSR(t *testing.T) {
-	fakeKubeClient := kubefake.NewSimpleClientset()
-
-	keyData, err := keyutil.MakeEllipticPrivateKeyPEM()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	controller := &ClientCertForHubController{
-		clusterName:  "cluster0",
-		agentName:    "agent0",
-		keyData:      keyData,
-		hubCSRClient: fakeKubeClient.CertificatesV1beta1().CertificateSigningRequests(),
-	}
-
-	csrName, err := controller.createCSR()
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	_, err = fakeKubeClient.CertificatesV1beta1().CertificateSigningRequests().Get(context.Background(), csrName, metav1.GetOptions{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-func TestSaveHubKubeconfigSecret(t *testing.T) {
-	secretNamespace := "default"
-	secretName := "secret"
-
-	fakeKubeClient := kubefake.NewSimpleClientset()
-
-	controller := &ClientCertForHubController{
-		hubKubeconfigSecretNamespace: secretNamespace,
-		hubKubeconfigSecretName:      secretName,
-		spokeCoreClient:              fakeKubeClient.CoreV1(),
-	}
-
-	key, value := "key", "value"
-	secret := newSecret(secretNamespace, secretName, "", map[string][]byte{
-		key: []byte(value),
-	})
-	err := controller.saveHubKubeconfigSecret(secret)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secret, err = fakeKubeClient.CoreV1().Secrets(secretNamespace).Get(context.Background(), secretName, metav1.GetOptions{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(secret.Data) == 0 {
-		t.Error("secret should have data stored")
-	}
-	if string(secret.Data[key]) != value {
-		t.Errorf("expected %q but get: %s", value, string(secret.Data[key]))
-	}
-}
-
-func TestSaveHubKubeconfigSecretWithExistingSecret(t *testing.T) {
-	secretNamespace := "default"
-	secretName := "secret"
-	secret := newSecret(secretNamespace, secretName, "1", nil)
-
-	fakeKubeClient := kubefake.NewSimpleClientset(secret)
-	controller := &ClientCertForHubController{
-		hubKubeconfigSecretNamespace: secretNamespace,
-		hubKubeconfigSecretName:      secretName,
-		spokeCoreClient:              fakeKubeClient.CoreV1(),
-	}
-
-	key, value := "key", "value"
-	secret.Data = map[string][]byte{
-		key: []byte(value),
-	}
-
-	err := controller.saveHubKubeconfigSecret(secret)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	secret, err = fakeKubeClient.CoreV1().Secrets(secretNamespace).Get(context.Background(), secretName, metav1.GetOptions{})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(secret.Data) == 0 {
-		t.Error("secret should have data stored")
-	}
-	if string(secret.Data[key]) != value {
-		t.Errorf("expected %q but get: %s", value, string(secret.Data[key]))
+			c.validateActions(t, hubKubeClient.Actions(), agentKubeClient.Actions())
+		})
 	}
 }

--- a/pkg/spoke/managedcluster/creating_controller_test.go
+++ b/pkg/spoke/managedcluster/creating_controller_test.go
@@ -1,13 +1,13 @@
 package managedcluster
 
 import (
-	"bytes"
 	"context"
 	"testing"
 
 	clusterfake "github.com/open-cluster-management/api/client/cluster/clientset/versioned/fake"
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
 	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	clienttesting "k8s.io/client-go/testing"
 )
@@ -19,23 +19,28 @@ func TestCreateSpokeCluster(t *testing.T) {
 		name            string
 		startingObjects []runtime.Object
 		validateActions func(t *testing.T, actions []clienttesting.Action)
-		expectedErr     string
 	}{
 		{
 			name:            "create a new cluster",
 			startingObjects: []runtime.Object{},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				assertActions(t, actions, "get", "create")
+				expectedClientConfigs := []clusterv1.ClientConfig{
+					{
+						URL:      testSpokeExternalServerUrl,
+						CABundle: []byte("testcabundle"),
+					},
+				}
+				testinghelpers.AssertActions(t, actions, "get", "create")
 				actual := actions[1].(clienttesting.CreateActionImpl).Object
-				assertSpokeExternalServerUrl(t, actual, testSpokeExternalServerUrl)
-				assertSpokeCABundle(t, actual, []byte("testcabundle"))
+				actualClientConfigs := actual.(*clusterv1.ManagedCluster).Spec.ManagedClusterClientConfigs
+				testinghelpers.AssertManagedClusterClientConfigs(t, actualClientConfigs, expectedClientConfigs)
 			},
 		},
 		{
 			name:            "create an existed cluster",
-			startingObjects: []runtime.Object{newManagedCluster()},
+			startingObjects: []runtime.Object{testinghelpers.NewManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				assertActions(t, actions, "get")
+				testinghelpers.AssertActions(t, actions, "get")
 			},
 		},
 	}
@@ -44,46 +49,18 @@ func TestCreateSpokeCluster(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			clusterClient := clusterfake.NewSimpleClientset(c.startingObjects...)
 			ctrl := managedClusterCreatingController{
-				clusterName:             testManagedClusterName,
+				clusterName:             testinghelpers.TestManagedClusterName,
 				spokeExternalServerURLs: []string{testSpokeExternalServerUrl},
 				spokeCABundle:           []byte("testcabundle"),
 				hubClusterClient:        clusterClient,
 			}
 
 			syncErr := ctrl.sync(context.TODO(), testinghelpers.NewFakeSyncContext(t, ""))
-			if len(c.expectedErr) > 0 && syncErr == nil {
-				t.Errorf("expected %q error", c.expectedErr)
-				return
-			}
-			if len(c.expectedErr) > 0 && syncErr != nil && syncErr.Error() != c.expectedErr {
-				t.Errorf("expected %q error, got %q", c.expectedErr, syncErr.Error())
-				return
-			}
-			if len(c.expectedErr) == 0 && syncErr != nil {
+			if syncErr != nil {
 				t.Errorf("unexpected err: %v", syncErr)
 			}
 
 			c.validateActions(t, clusterClient.Actions())
 		})
-	}
-}
-
-func assertSpokeExternalServerUrl(t *testing.T, actual runtime.Object, expected string) {
-	spokeCluster := actual.(*clusterv1.ManagedCluster)
-	if len(spokeCluster.Spec.ManagedClusterClientConfigs) != 1 {
-		t.Errorf("expected one spoke client config, but got %v", spokeCluster.Spec.ManagedClusterClientConfigs)
-	}
-	if spokeCluster.Spec.ManagedClusterClientConfigs[0].URL != expected {
-		t.Errorf("expected %q error, but got %q", expected, spokeCluster.Spec.ManagedClusterClientConfigs[0].URL)
-	}
-}
-
-func assertSpokeCABundle(t *testing.T, actual runtime.Object, expected []byte) {
-	spokeCluster := actual.(*clusterv1.ManagedCluster)
-	if len(spokeCluster.Spec.ManagedClusterClientConfigs) != 1 {
-		t.Errorf("expected one spoke client config, but got %v", spokeCluster.Spec.ManagedClusterClientConfigs)
-	}
-	if !bytes.Equal(spokeCluster.Spec.ManagedClusterClientConfigs[0].CABundle, expected) {
-		t.Errorf("expected %q error, but got %q", expected, spokeCluster.Spec.ManagedClusterClientConfigs[0].CABundle)
 	}
 }

--- a/pkg/spoke/managedcluster/joining_controller_test.go
+++ b/pkg/spoke/managedcluster/joining_controller_test.go
@@ -2,29 +2,22 @@ package managedcluster
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
 	clusterfake "github.com/open-cluster-management/api/client/cluster/clientset/versioned/fake"
 	clusterinformers "github.com/open-cluster-management/api/client/cluster/informers/externalversions"
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
-	"github.com/open-cluster-management/registration/pkg/helpers"
-
 	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/version"
 	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	kubeversion "k8s.io/client-go/pkg/version"
 	clienttesting "k8s.io/client-go/testing"
 )
-
-const testManagedClusterName = "testmanagedcluster"
 
 func TestSyncManagedCluster(t *testing.T) {
 	cases := []struct {
@@ -37,67 +30,89 @@ func TestSyncManagedCluster(t *testing.T) {
 		{
 			name:            "sync no managed cluster",
 			startingObjects: []runtime.Object{},
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 0 {
-					t.Errorf("expected 0 call but got: %#v", actions)
-				}
-			},
-			expectedErr: "unable to get managed cluster with name \"testmanagedcluster\" from hub: managedcluster.cluster.open-cluster-management.io \"testmanagedcluster\" not found",
+			validateActions: testinghelpers.AssertNoActions,
+			expectedErr:     "unable to get managed cluster with name \"testmanagedcluster\" from hub: managedcluster.cluster.open-cluster-management.io \"testmanagedcluster\" not found",
 		},
 		{
 			name:            "sync an unaccepted managed cluster",
-			startingObjects: []runtime.Object{newManagedCluster()},
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 0 {
-					t.Errorf("expected 0 call but got: %#v", actions)
-				}
-			},
+			startingObjects: []runtime.Object{testinghelpers.NewManagedCluster()},
+			validateActions: testinghelpers.AssertNoActions,
 		},
 		{
 			name:            "sync an accepted managed cluster",
-			startingObjects: []runtime.Object{newAcceptedManagedCluster()},
-			nodes:           []runtime.Object{newNode("testnode1", newResourceList(32, 64), newResourceList(16, 32))},
+			startingObjects: []runtime.Object{testinghelpers.NewAcceptedManagedCluster()},
+			nodes: []runtime.Object{
+				testinghelpers.NewNode("testnode1", testinghelpers.NewResourceList(32, 64), testinghelpers.NewResourceList(16, 32)),
+			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				assertActions(t, actions, "get", "update")
-				actual := actions[1].(clienttesting.UpdateActionImpl).Object
 				expectedCondition := clusterv1.StatusCondition{
 					Type:    clusterv1.ManagedClusterConditionJoined,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ManagedClusterJoined",
 					Message: "Managed cluster joined",
 				}
-				assertCondition(t, actual, expectedCondition)
-				assertStatusVersion(t, actual, kubeversion.Get())
-				assertStatusResource(t, actual, newResourceList(32, 64), newResourceList(16, 32))
+				expectedStatus := clusterv1.ManagedClusterStatus{
+					Version: clusterv1.ManagedClusterVersion{
+						Kubernetes: kubeversion.Get().GitVersion,
+					},
+					Capacity: clusterv1.ResourceList{
+						clusterv1.ResourceCPU:    *resource.NewQuantity(int64(32), resource.DecimalExponent),
+						clusterv1.ResourceMemory: *resource.NewQuantity(int64(1024*1024*64), resource.BinarySI),
+					},
+					Allocatable: clusterv1.ResourceList{
+						clusterv1.ResourceCPU:    *resource.NewQuantity(int64(16), resource.DecimalExponent),
+						clusterv1.ResourceMemory: *resource.NewQuantity(int64(1024*1024*32), resource.BinarySI),
+					},
+				}
+				testinghelpers.AssertActions(t, actions, "get", "update")
+				actual := actions[1].(clienttesting.UpdateActionImpl).Object
+				testinghelpers.AssertManagedClusterCondition(t, actual.(*clusterv1.ManagedCluster).Status.Conditions, expectedCondition)
+				testinghelpers.AssertManagedClusterStatus(t, actual.(*clusterv1.ManagedCluster).Status, expectedStatus)
 			},
 		},
 		{
-			name:            "sync a joined managed cluster without status change",
-			startingObjects: []runtime.Object{newJoinedManagedCluster(newResourceList(32, 64), newResourceList(16, 32))},
-			nodes:           []runtime.Object{newNode("testnode1", newResourceList(32, 64), newResourceList(16, 32))},
+			name: "sync a joined managed cluster without status change",
+			startingObjects: []runtime.Object{
+				testinghelpers.NewManagedClusterWithStatus(testinghelpers.NewResourceList(32, 64), testinghelpers.NewResourceList(16, 32)),
+			},
+			nodes: []runtime.Object{
+				testinghelpers.NewNode("testnode1", testinghelpers.NewResourceList(32, 64), testinghelpers.NewResourceList(16, 32)),
+			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				assertActions(t, actions, "get")
+				testinghelpers.AssertActions(t, actions, "get")
 			},
 		},
 		{
 			name:            "sync a joined managed cluster with status change",
-			startingObjects: []runtime.Object{newJoinedManagedCluster(newResourceList(32, 64), newResourceList(16, 32))},
+			startingObjects: []runtime.Object{testinghelpers.NewJoinedManagedCluster()},
 			nodes: []runtime.Object{
-				newNode("testnode1", newResourceList(32, 64), newResourceList(16, 32)),
-				newNode("testnode2", newResourceList(32, 64), newResourceList(16, 32)),
+				testinghelpers.NewNode("testnode1", testinghelpers.NewResourceList(32, 64), testinghelpers.NewResourceList(16, 32)),
+				testinghelpers.NewNode("testnode2", testinghelpers.NewResourceList(32, 64), testinghelpers.NewResourceList(16, 32)),
 			},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				assertActions(t, actions, "get", "update")
-				actual := actions[1].(clienttesting.UpdateActionImpl).Object
 				expectedCondition := clusterv1.StatusCondition{
 					Type:    clusterv1.ManagedClusterConditionJoined,
 					Status:  metav1.ConditionTrue,
 					Reason:  "ManagedClusterJoined",
 					Message: "Managed cluster joined",
 				}
-				assertCondition(t, actual, expectedCondition)
-				assertStatusVersion(t, actual, kubeversion.Get())
-				assertStatusResource(t, actual, newResourceList(64, 128), newResourceList(32, 64))
+				expectedStatus := clusterv1.ManagedClusterStatus{
+					Version: clusterv1.ManagedClusterVersion{
+						Kubernetes: kubeversion.Get().GitVersion,
+					},
+					Capacity: clusterv1.ResourceList{
+						clusterv1.ResourceCPU:    *resource.NewQuantity(int64(64), resource.DecimalExponent),
+						clusterv1.ResourceMemory: *resource.NewQuantity(int64(1024*1024*128), resource.BinarySI),
+					},
+					Allocatable: clusterv1.ResourceList{
+						clusterv1.ResourceCPU:    *resource.NewQuantity(int64(32), resource.DecimalExponent),
+						clusterv1.ResourceMemory: *resource.NewQuantity(int64(1024*1024*64), resource.BinarySI),
+					},
+				}
+				testinghelpers.AssertActions(t, actions, "get", "update")
+				actual := actions[1].(clienttesting.UpdateActionImpl).Object
+				testinghelpers.AssertManagedClusterCondition(t, actual.(*clusterv1.ManagedCluster).Status.Conditions, expectedCondition)
+				testinghelpers.AssertManagedClusterStatus(t, actual.(*clusterv1.ManagedCluster).Status, expectedStatus)
 			},
 		},
 	}
@@ -119,7 +134,7 @@ func TestSyncManagedCluster(t *testing.T) {
 			}
 
 			ctrl := managedClusterJoiningController{
-				clusterName:      testManagedClusterName,
+				clusterName:      testinghelpers.TestManagedClusterName,
 				hubClusterClient: clusterClient,
 				hubClusterLister: clusterInformerFactory.Cluster().V1().ManagedClusters().Lister(),
 				discoveryClient:  kubeClient.Discovery(),
@@ -127,150 +142,9 @@ func TestSyncManagedCluster(t *testing.T) {
 			}
 
 			syncErr := ctrl.sync(context.TODO(), testinghelpers.NewFakeSyncContext(t, ""))
-			if len(c.expectedErr) > 0 && syncErr == nil {
-				t.Errorf("expected %q error", c.expectedErr)
-				return
-			}
-			if len(c.expectedErr) > 0 && syncErr != nil && syncErr.Error() != c.expectedErr {
-				t.Errorf("expected %q error, got %q", c.expectedErr, syncErr.Error())
-				return
-			}
-			if len(c.expectedErr) == 0 && syncErr != nil {
-				t.Errorf("unexpected err: %v", syncErr)
-			}
+			testinghelpers.AssertError(t, syncErr, c.expectedErr)
 
 			c.validateActions(t, clusterClient.Actions())
 		})
-	}
-}
-
-func assertActions(t *testing.T, actualActions []clienttesting.Action, expectedActions ...string) {
-	if len(actualActions) != len(expectedActions) {
-		t.Errorf("expected %d call but got: %#v", len(expectedActions), actualActions)
-	}
-	for i, expected := range expectedActions {
-		if actualActions[i].GetVerb() != expected {
-			t.Errorf("expected %s action but got: %#v", expected, actualActions[i])
-		}
-	}
-}
-
-func assertManagedCluster(t *testing.T, actual runtime.Object, expectedName string) {
-	managedCluster, ok := actual.(*clusterv1.ManagedCluster)
-	if !ok {
-		t.Errorf("expected managed cluster but got: %#v", actual)
-	}
-	if managedCluster.Name != expectedName {
-		t.Errorf("expected %s but got: %#v", expectedName, managedCluster.Name)
-	}
-}
-
-func assertCondition(t *testing.T, actual runtime.Object, expectedCondition clusterv1.StatusCondition) {
-	managedCluster := actual.(*clusterv1.ManagedCluster)
-	cond := helpers.FindManagedClusterCondition(managedCluster.Status.Conditions, expectedCondition.Type)
-	if cond == nil {
-		t.Errorf("expected condition %s but got: %s", expectedCondition.Type, cond.Type)
-	}
-	if cond.Status != expectedCondition.Status {
-		t.Errorf("expected status %s but got: %s", expectedCondition.Status, cond.Status)
-	}
-	if cond.Reason != expectedCondition.Reason {
-		t.Errorf("expected reason %s but got: %s", expectedCondition.Reason, cond.Reason)
-	}
-	if cond.Message != expectedCondition.Message {
-		t.Errorf("expected message %s but got: %s", expectedCondition.Message, cond.Message)
-	}
-}
-
-func assertStatusVersion(t *testing.T, actual runtime.Object, expected version.Info) {
-	managedCluster := actual.(*clusterv1.ManagedCluster)
-	if !reflect.DeepEqual(managedCluster.Status.Version, clusterv1.ManagedClusterVersion{
-		Kubernetes: expected.GitVersion,
-	}) {
-		t.Errorf("expected %s but got: %#v", expected, managedCluster.Status.Version)
-	}
-}
-
-func assertStatusResource(t *testing.T, actual runtime.Object, expectedCapacity, expectedAllocatable corev1.ResourceList) {
-	managedCluster := actual.(*clusterv1.ManagedCluster)
-	if !reflect.DeepEqual(managedCluster.Status.Capacity["cpu"], expectedCapacity["cpu"]) {
-		t.Errorf("expected %#v but got: %#v", expectedCapacity, managedCluster.Status.Capacity)
-	}
-	if !reflect.DeepEqual(managedCluster.Status.Capacity["memory"], expectedCapacity["memory"]) {
-		t.Errorf("expected %#v but got: %#v", expectedCapacity, managedCluster.Status.Capacity)
-	}
-	if !reflect.DeepEqual(managedCluster.Status.Allocatable["cpu"], expectedAllocatable["cpu"]) {
-		t.Errorf("expected %#v but got: %#v", expectedAllocatable, managedCluster.Status.Allocatable)
-	}
-	if !reflect.DeepEqual(managedCluster.Status.Allocatable["memory"], expectedAllocatable["memory"]) {
-		t.Errorf("expected %#v but got: %#v", expectedAllocatable, managedCluster.Status.Allocatable)
-	}
-}
-
-func newManagedCluster(conditions ...clusterv1.StatusCondition) *clusterv1.ManagedCluster {
-	return &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: testManagedClusterName,
-		},
-		Status: clusterv1.ManagedClusterStatus{
-			Conditions: conditions,
-		},
-	}
-}
-
-func newAcceptedManagedCluster() *clusterv1.ManagedCluster {
-	return newManagedCluster(clusterv1.StatusCondition{
-		Type:    clusterv1.ManagedClusterConditionHubAccepted,
-		Status:  metav1.ConditionTrue,
-		Reason:  "HubClusterAdminAccepted",
-		Message: "Accepted by hub cluster admin",
-	})
-}
-
-func newJoinedManagedCluster(capacity, allocatable corev1.ResourceList) *clusterv1.ManagedCluster {
-	managedCluster := newManagedCluster(
-		clusterv1.StatusCondition{
-			Type:    clusterv1.ManagedClusterConditionHubAccepted,
-			Status:  metav1.ConditionTrue,
-			Reason:  "HubClusterAdminAccepted",
-			Message: "Accepted by hub cluster admin",
-		},
-		clusterv1.StatusCondition{
-			Type:    clusterv1.ManagedClusterConditionJoined,
-			Status:  metav1.ConditionTrue,
-			Reason:  "ManagedClusterJoined",
-			Message: "Managed cluster joined",
-		},
-	)
-	managedCluster.Status.Capacity = clusterv1.ResourceList{
-		"cpu":    capacity.Cpu().DeepCopy(),
-		"memory": capacity.Memory().DeepCopy(),
-	}
-	managedCluster.Status.Allocatable = clusterv1.ResourceList{
-		"cpu":    allocatable.Cpu().DeepCopy(),
-		"memory": allocatable.Memory().DeepCopy(),
-	}
-	managedCluster.Status.Version = clusterv1.ManagedClusterVersion{
-		Kubernetes: kubeversion.Get().GitVersion,
-	}
-	return managedCluster
-}
-
-func newResourceList(cpu, mem int) corev1.ResourceList {
-	return corev1.ResourceList{
-		corev1.ResourceCPU:    *resource.NewQuantity(int64(cpu), resource.DecimalExponent),
-		corev1.ResourceMemory: *resource.NewQuantity(int64(1024*1024*mem), resource.BinarySI),
-	}
-}
-
-func newNode(name string, capacity, allocatable corev1.ResourceList) *corev1.Node {
-	return &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Status: corev1.NodeStatus{
-			Capacity:    capacity,
-			Allocatable: allocatable,
-		},
 	}
 }

--- a/pkg/spoke/managedcluster/lease_controller_test.go
+++ b/pkg/spoke/managedcluster/lease_controller_test.go
@@ -8,19 +8,15 @@ import (
 
 	clusterfake "github.com/open-cluster-management/api/client/cluster/clientset/versioned/fake"
 	clusterinformers "github.com/open-cluster-management/api/client/cluster/informers/externalversions"
-	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
 	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
 
 	"github.com/openshift/library-go/pkg/operator/events/eventstesting"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 )
-
-const testLeaseDurationSeconds int32 = 1
 
 func TestLeaseUpdate(t *testing.T) {
 	cases := []struct {
@@ -32,30 +28,26 @@ func TestLeaseUpdate(t *testing.T) {
 	}{
 		{
 			name:     "start lease update routine",
-			clusters: []runtime.Object{newAcceptedManagedClusterWithLeaseDuration()},
+			clusters: []runtime.Object{testinghelpers.NewAcceptedManagedCluster()},
 			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				assertLeaseUpdateActions(t, actions)
+				testinghelpers.AssertUpdateActions(t, actions)
 				leaseObj := actions[1].(clienttesting.UpdateActionImpl).Object
 				lastLeaseObj := actions[len(actions)-1].(clienttesting.UpdateActionImpl).Object
-				assertLeaseUpdated(t, leaseObj, lastLeaseObj)
+				testinghelpers.AssertLeaseUpdated(t, leaseObj.(*coordinationv1.Lease), lastLeaseObj.(*coordinationv1.Lease))
 			},
 		},
 		{
 			name:                    "delete a managed cluster after lease update routine is started",
 			clusters:                []runtime.Object{},
 			needToStartUpdateBefore: true,
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				assertNoMoreUpdates(t, actions)
-			},
-			expectedErr: "unable to get managed cluster \"testmanagedcluster\" from hub: managedcluster.cluster.open-cluster-management.io \"testmanagedcluster\" not found",
+			validateActions:         testinghelpers.AssertNoMoreUpdates,
+			expectedErr:             "unable to get managed cluster \"testmanagedcluster\" from hub: managedcluster.cluster.open-cluster-management.io \"testmanagedcluster\" not found",
 		},
 		{
 			name:                    "unaccept a managed cluster after lease update routine is started",
-			clusters:                []runtime.Object{newManagedCluster()},
+			clusters:                []runtime.Object{testinghelpers.NewManagedCluster()},
 			needToStartUpdateBefore: true,
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				assertNoMoreUpdates(t, actions)
-			},
+			validateActions:         testinghelpers.AssertNoMoreUpdates,
 		},
 	}
 
@@ -68,85 +60,32 @@ func TestLeaseUpdate(t *testing.T) {
 				clusterStore.Add(cluster)
 			}
 
-			hubClient := kubefake.NewSimpleClientset(&coordinationv1.Lease{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "cluster-lease-testmanagedcluster",
-					Namespace: "testmanagedcluster",
-				},
-			})
+			hubClient := kubefake.NewSimpleClientset(testinghelpers.NewManagedClusterLease(time.Now()))
 
 			leaseUpdater := &leaseUpdater{
 				hubClient:   hubClient,
-				clusterName: testManagedClusterName,
-				leaseName:   fmt.Sprintf("cluster-lease-%s", testManagedClusterName),
+				clusterName: testinghelpers.TestManagedClusterName,
+				leaseName:   fmt.Sprintf("cluster-lease-%s", testinghelpers.TestManagedClusterName),
 				recorder:    eventstesting.NewTestingEventRecorder(t),
 			}
 
 			if c.needToStartUpdateBefore {
-				leaseUpdater.start(context.TODO(), time.Duration(testLeaseDurationSeconds)*time.Second)
+				leaseUpdater.start(context.TODO(), time.Duration(testinghelpers.TestLeaseDurationSeconds)*time.Second)
 				// wait a few milliseconds to start the lease update routine
 				time.Sleep(200 * time.Millisecond)
 			}
 
 			ctrl := &managedClusterLeaseController{
-				clusterName:      testManagedClusterName,
+				clusterName:      testinghelpers.TestManagedClusterName,
 				hubClusterLister: clusterInformerFactory.Cluster().V1().ManagedClusters().Lister(),
 				leaseUpdater:     leaseUpdater,
 			}
 			syncErr := ctrl.sync(context.TODO(), testinghelpers.NewFakeSyncContext(t, ""))
-			if len(c.expectedErr) > 0 && syncErr == nil {
-				t.Errorf("expected %q error", c.expectedErr)
-				return
-			}
-			if len(c.expectedErr) > 0 && syncErr != nil && syncErr.Error() != c.expectedErr {
-				t.Errorf("expected %q error, got %q", c.expectedErr, syncErr.Error())
-				return
-			}
-			if len(c.expectedErr) == 0 && syncErr != nil {
-				t.Errorf("unexpected err: %v", syncErr)
-			}
+			testinghelpers.AssertError(t, syncErr, c.expectedErr)
 
 			// wait one cycle
 			time.Sleep(1200 * time.Millisecond)
 			c.validateActions(t, hubClient.Actions())
 		})
-	}
-}
-
-func newAcceptedManagedClusterWithLeaseDuration() *clusterv1.ManagedCluster {
-	cluster := newAcceptedManagedCluster()
-	cluster.Spec.LeaseDurationSeconds = testLeaseDurationSeconds
-	return cluster
-}
-
-func assertLeaseUpdateActions(t *testing.T, actions []clienttesting.Action) {
-	for i := 0; i < len(actions); i = i + 2 {
-		if actions[i].GetVerb() != "get" {
-			t.Errorf("expected action %d is get, but %v", i, actions[i])
-		}
-		if actions[i+1].GetVerb() != "update" {
-			t.Errorf("expected action %d is update, but %v", i, actions[i+1])
-		}
-	}
-}
-
-func assertLeaseUpdated(t *testing.T, lease, lastLeaseObj runtime.Object) {
-	firstRenewTime := lease.(*coordinationv1.Lease).Spec.RenewTime
-	lastRenewTime := lastLeaseObj.(*coordinationv1.Lease).Spec.RenewTime
-	if !firstRenewTime.BeforeTime(&metav1.Time{Time: lastRenewTime.Time}) {
-		t.Errorf("expected lease updated, but failed")
-	}
-}
-
-func assertNoMoreUpdates(t *testing.T, actions []clienttesting.Action) {
-	updateActions := 0
-	for _, action := range actions {
-		if action.GetVerb() == "update" {
-			updateActions++
-		}
-	}
-	// make sure the lease update routine is started and no more update actions
-	if updateActions != 1 {
-		t.Errorf("expected there is only one update action, but failed")
 	}
 }

--- a/pkg/spoke/spokeagent_test.go
+++ b/pkg/spoke/spokeagent_test.go
@@ -8,171 +8,259 @@ import (
 	"testing"
 	"time"
 
+	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
 	"github.com/open-cluster-management/registration/pkg/spoke/hubclientcert"
+
 	"k8s.io/client-go/rest"
 )
 
-func TestGetOrGenerateClusterAgentNames(t *testing.T) {
-	o := &SpokeAgentOptions{
-		HubKubeconfigDir: "/path/not/existing",
+func TestComplete(t *testing.T) {
+	options := NewSpokeAgentOptions()
+	if err := options.Complete(); err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
-
-	clusterName, agentName := o.getOrGenerateClusterAgentNames()
-	if clusterName == "" {
+	if options.ComponentNamespace == "" {
+		t.Error("component namespace should not be empty")
+	}
+	if options.ClusterName == "" {
 		t.Error("cluster name should not be empty")
 	}
-
-	if agentName == "" {
+	if options.AgentName == "" {
 		t.Error("agent name should not be empty")
-	}
-}
-
-func TestGetOrGenerateClusterAgentNamesWithClusterNameOverride(t *testing.T) {
-	dir, err := ioutil.TempDir("", "prefix")
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	o := &SpokeAgentOptions{
-		HubKubeconfigDir: "/path/not/existing",
-		ClusterName:      "cluster0",
-	}
-
-	clusterName, agentName := o.getOrGenerateClusterAgentNames()
-
-	if clusterName != o.ClusterName {
-		t.Errorf("expect cluster name %q but got %q", o.ClusterName, clusterName)
-	}
-
-	if agentName == "" {
-		t.Error("agent name should not be empty")
-	}
-}
-
-func TestGetOrGenerateClusterAgentNamesWithExistingNames(t *testing.T) {
-	dir, err := ioutil.TempDir("", "prefix")
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	cn, an := "cluster0", "agent0"
-
-	clusterNameFilePath := path.Join(dir, hubclientcert.ClusterNameFile)
-	err = ioutil.WriteFile(clusterNameFilePath, []byte(cn), 0644)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	agentNameFilePath := path.Join(dir, hubclientcert.AgentNameFile)
-	err = ioutil.WriteFile(agentNameFilePath, []byte(an), 0644)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-
-	o := &SpokeAgentOptions{
-		HubKubeconfigDir: dir,
-	}
-
-	clusterName, agentName := o.getOrGenerateClusterAgentNames()
-
-	if clusterName != cn {
-		t.Errorf("expect cluster name %q but got %q", cn, clusterName)
-	}
-
-	if agentName != an {
-		t.Errorf("expect agent name %q but got %q", an, agentName)
 	}
 }
 
 func TestValidate(t *testing.T) {
-	var err error
+	defaultCompletedOptions := NewSpokeAgentOptions()
+	defaultCompletedOptions.BootstrapKubeconfig = "/spoke/bootstrap/kubeconfig"
+	defaultCompletedOptions.ClusterName = "testcluster"
+	defaultCompletedOptions.AgentName = "testagent"
 
-	withoutBootstrapKubeconfig := &SpokeAgentOptions{}
-	err = withoutBootstrapKubeconfig.Validate()
-	if err == nil || err.Error() != "bootstrap-kubeconfig is required" {
-		t.Errorf("expect 'bootstrap-kubeconfig is required' error but got %v", err)
+	cases := []struct {
+		name        string
+		options     *SpokeAgentOptions
+		expectedErr string
+	}{
+		{
+			name:        "no bootstrap kubeconfig",
+			options:     &SpokeAgentOptions{},
+			expectedErr: "bootstrap-kubeconfig is required",
+		},
+		{
+			name:        "no cluster name",
+			options:     &SpokeAgentOptions{BootstrapKubeconfig: "/spoke/bootstrap/kubeconfig"},
+			expectedErr: "cluster name is empty",
+		},
+		{
+			name:        "no agent name",
+			options:     &SpokeAgentOptions{BootstrapKubeconfig: "/spoke/bootstrap/kubeconfig", ClusterName: "testcluster"},
+			expectedErr: "agent name is empty",
+		},
+		{
+			name: "invalid external server URLs",
+			options: &SpokeAgentOptions{
+				BootstrapKubeconfig:     "/spoke/bootstrap/kubeconfig",
+				ClusterName:             "testcluster",
+				AgentName:               "testagent",
+				SpokeExternalServerURLs: []string{"https://127.0.0.1:64433", "http://127.0.0.1:8080"},
+			},
+			expectedErr: "\"http://127.0.0.1:8080\" is invalid",
+		},
+		{
+			name: "invalid cluster healthcheck period",
+			options: &SpokeAgentOptions{
+				BootstrapKubeconfig:      "/spoke/bootstrap/kubeconfig",
+				ClusterName:              "testcluster",
+				AgentName:                "testagent",
+				ClusterHealthCheckPeriod: 0,
+			},
+			expectedErr: "cluster healthcheck period must greater than zero",
+		},
+		{
+			name:        "default completed options",
+			options:     defaultCompletedOptions,
+			expectedErr: "",
+		},
 	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.options.Validate()
+			testinghelpers.AssertError(t, err, c.expectedErr)
+		})
+	}
+}
 
-	withoutClusterName := &SpokeAgentOptions{
-		BootstrapKubeconfig: "/spoke/bootstrap/kubeconfig",
-	}
-	err = withoutClusterName.Validate()
-	if err == nil || err.Error() != "cluster name is empty" {
-		t.Errorf("expect \"cluster name is empty\" error but got %v", err)
-	}
-
-	withoutAgentName := &SpokeAgentOptions{
-		BootstrapKubeconfig: "/spoke/bootstrap/kubeconfig",
-		ClusterName:         "testcluster",
-	}
-	err = withoutAgentName.Validate()
-	if err == nil || err.Error() != "agent name is empty" {
-		t.Errorf("expect \"agent name is empty\" error but got %v", err)
-	}
-
-	withoutSpokeExternalServerURLs := &SpokeAgentOptions{
-		BootstrapKubeconfig:      "/spoke/bootstrap/kubeconfig",
-		ClusterName:              "testcluster",
-		AgentName:                "testagent",
-		ClusterHealthCheckPeriod: 1 * time.Minute,
-	}
-	err = withoutSpokeExternalServerURLs.Validate()
+func TestHasValidHubClientConfig(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "testvalidhubclientconfig")
 	if err != nil {
-		t.Errorf("expect no error but got %v", err)
+		t.Errorf("unexpected error: %v", err)
 	}
+	defer os.RemoveAll(tempDir)
 
-	withInvalidSpokeExternalServerURL := &SpokeAgentOptions{
-		BootstrapKubeconfig:     "/spoke/bootstrap/kubeconfig",
-		ClusterName:             "testcluster",
-		AgentName:               "testagent",
-		SpokeExternalServerURLs: []string{"https://127.0.0.1:64433", "http://127.0.0.1:8080"},
-	}
-	err = withInvalidSpokeExternalServerURL.Validate()
-	if err == nil || err.Error() != "\"http://127.0.0.1:8080\" is invalid" {
-		t.Errorf("expect \"http://127.0.0.1:8080 is invalid\" error but got %v", err)
-	}
+	cert := testinghelpers.NewTestCert("test", 60*time.Second)
+	kubeconfig := testinghelpers.NewKubeconfig(cert.Key, cert.Cert)
 
-	withInvalidClusterHealthCheckPeriod := &SpokeAgentOptions{
-		BootstrapKubeconfig:      "/spoke/bootstrap/kubeconfig",
-		ClusterName:              "testcluster",
-		AgentName:                "testagent",
-		ClusterHealthCheckPeriod: 0,
+	cases := []struct {
+		name       string
+		kubeconfig []byte
+		tlsCert    []byte
+		tlsKey     []byte
+		isValid    bool
+	}{
+		{
+			name:    "no kubeconfig",
+			isValid: false,
+		},
+		{
+			name:       "no tls key",
+			kubeconfig: kubeconfig,
+			isValid:    false,
+		},
+		{
+			name:       "no tls cert",
+			kubeconfig: kubeconfig,
+			tlsKey:     cert.Key,
+			isValid:    false,
+		},
+		{
+			name:       "valid hub client config",
+			kubeconfig: kubeconfig,
+			tlsKey:     cert.Key,
+			tlsCert:    cert.Cert,
+			isValid:    true,
+		},
 	}
-	err = withInvalidClusterHealthCheckPeriod.Validate()
-	if err == nil || err.Error() != "cluster healthcheck period must greater than zero" {
-		t.Errorf("expect no error but got %v", err)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.kubeconfig != nil {
+				testinghelpers.WriteFile(path.Join(tempDir, "kubeconfig"), c.kubeconfig)
+			}
+			if c.tlsKey != nil {
+				testinghelpers.WriteFile(path.Join(tempDir, "tls.key"), c.tlsKey)
+			}
+			if c.tlsCert != nil {
+				testinghelpers.WriteFile(path.Join(tempDir, "tls.crt"), c.tlsCert)
+			}
+
+			options := &SpokeAgentOptions{HubKubeconfigDir: tempDir}
+			valid, err := options.hasValidHubClientConfig()
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if c.isValid != valid {
+				t.Errorf("expect %t, but %t", c.isValid, valid)
+			}
+		})
+	}
+}
+
+func TestGetOrGenerateClusterAgentNames(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "testgetorgenerateclusteragentnames")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cases := []struct {
+		name                string
+		options             *SpokeAgentOptions
+		expectedClusterName string
+		expectedAgentName   string
+	}{
+		{
+			name:                "cluster name is specified",
+			options:             &SpokeAgentOptions{ClusterName: "cluster0"},
+			expectedClusterName: "cluster0",
+		},
+		{
+			name:                "cluster name and agent name are in file",
+			options:             &SpokeAgentOptions{HubKubeconfigDir: tempDir},
+			expectedClusterName: "cluster1",
+			expectedAgentName:   "agent1",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.options.HubKubeconfigDir != "" {
+				testinghelpers.WriteFile(path.Join(tempDir, hubclientcert.ClusterNameFile), []byte(c.expectedClusterName))
+				testinghelpers.WriteFile(path.Join(tempDir, hubclientcert.AgentNameFile), []byte(c.expectedAgentName))
+			}
+			clusterName, agentName := c.options.getOrGenerateClusterAgentNames()
+			if clusterName != c.expectedClusterName {
+				t.Errorf("expect cluster name %q but got %q", c.expectedClusterName, clusterName)
+			}
+
+			// agent name cannot be empty, it is either generated or from file
+			if agentName == "" {
+				t.Error("agent name should not be empty")
+			}
+
+			if c.expectedAgentName != "" && c.expectedAgentName != agentName {
+				t.Errorf("expect agent name %q but got %q", c.expectedAgentName, agentName)
+			}
+		})
 	}
 }
 
 func TestGetSpokeClusterCABundle(t *testing.T) {
-	withoutSpokeExternalServerURLs := &SpokeAgentOptions{}
-	caData, err := withoutSpokeExternalServerURLs.getSpokeClusterCABundle(&rest.Config{})
-	if err != nil {
-		t.Errorf("expect no error but got %v", err)
-	}
-	if caData != nil {
-		t.Errorf("expect no ca data but got %v", caData)
-	}
-
-	withSpokeExternalServerURLs := &SpokeAgentOptions{SpokeExternalServerURLs: []string{"https://127.0.0.1:6443"}}
-	caData, err = withSpokeExternalServerURLs.getSpokeClusterCABundle(&rest.Config{})
-	if err == nil {
-		t.Errorf("expect error happened but no error")
-	}
-	if caData != nil {
-		t.Errorf("expect no ca data but got %v", caData)
-	}
-
-	expectedCAData := []byte("cadata")
-	caData, err = withSpokeExternalServerURLs.getSpokeClusterCABundle(&rest.Config{
-		TLSClientConfig: rest.TLSClientConfig{CAData: expectedCAData},
-	})
+	tempDir, err := ioutil.TempDir("", "testgetspokeclustercabundle")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if !bytes.Equal(caData, expectedCAData) {
-		t.Errorf("expected %v but got %v", expectedCAData, caData)
+	defer os.RemoveAll(tempDir)
+
+	cases := []struct {
+		name           string
+		caFile         string
+		options        *SpokeAgentOptions
+		expectedErr    string
+		expectedCAData []byte
+	}{
+		{
+			name:           "no external server URLs",
+			options:        &SpokeAgentOptions{},
+			expectedErr:    "",
+			expectedCAData: nil,
+		},
+		{
+			name:           "no ca data",
+			options:        &SpokeAgentOptions{SpokeExternalServerURLs: []string{"https://127.0.0.1:6443"}},
+			expectedErr:    "open : no such file or directory",
+			expectedCAData: nil,
+		},
+		{
+			name:           "has ca data",
+			options:        &SpokeAgentOptions{SpokeExternalServerURLs: []string{"https://127.0.0.1:6443"}},
+			expectedErr:    "",
+			expectedCAData: []byte("cadata"),
+		},
+		{
+			name:           "has ca file",
+			caFile:         "ca.data",
+			options:        &SpokeAgentOptions{SpokeExternalServerURLs: []string{"https://127.0.0.1:6443"}},
+			expectedErr:    "",
+			expectedCAData: []byte("cadata"),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			restConig := &rest.Config{}
+			if c.expectedCAData != nil {
+				restConig.CAData = c.expectedCAData
+			}
+			if c.caFile != "" {
+				testinghelpers.WriteFile(path.Join(tempDir, c.caFile), c.expectedCAData)
+				restConig.CAData = nil
+				restConig.CAFile = path.Join(tempDir, c.caFile)
+			}
+			caData, err := c.options.getSpokeClusterCABundle(restConig)
+			testinghelpers.AssertError(t, err, c.expectedErr)
+			if c.expectedCAData == nil && caData == nil {
+				return
+			}
+			if !bytes.Equal(caData, c.expectedCAData) {
+				t.Errorf("expect %v but got %v", c.expectedCAData, caData)
+			}
+		})
 	}
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -6,18 +6,19 @@ import (
 	"fmt"
 	"net/http"
 
+	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
+	"github.com/open-cluster-management/registration/pkg/helpers"
+
+	operatorhelpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-
-	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
-	"github.com/open-cluster-management/registration/pkg/helpers"
-	operatorhelpers "github.com/openshift/library-go/pkg/operator/v1helpers"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 )
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	clusterv1 "github.com/open-cluster-management/api/cluster/v1"
+	testinghelpers "github.com/open-cluster-management/registration/pkg/helpers/testing"
+
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -22,7 +24,7 @@ var managedclustersSchema = metav1.GroupVersionResource{
 	Resource: "managedclusters",
 }
 
-func TestSpokeClusterValidate(t *testing.T) {
+func TestManagedClusterValidate(t *testing.T) {
 	cases := []struct {
 		name                   string
 		request                *admissionv1beta1.AdmissionRequest
@@ -177,42 +179,26 @@ func TestSpokeClusterValidate(t *testing.T) {
 }
 
 func newManagedClusterObj() runtime.RawExtension {
-	spokeCluster := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "testspokecluster",
-		},
-	}
-	clusterObj, _ := json.Marshal(spokeCluster)
+	managedCluster := testinghelpers.NewManagedCluster()
+	clusterObj, _ := json.Marshal(managedCluster)
 	return runtime.RawExtension{
 		Raw: clusterObj,
 	}
 }
 
 func newManagedClusterObjWithHubAcceptsClient(hubAcceptsClient bool) runtime.RawExtension {
-	spokeCluster := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "testspokecluster",
-		},
-		Spec: clusterv1.ManagedClusterSpec{
-			HubAcceptsClient: hubAcceptsClient,
-		},
-	}
-	clusterObj, _ := json.Marshal(spokeCluster)
+	managedCluster := testinghelpers.NewManagedCluster()
+	managedCluster.Spec.HubAcceptsClient = hubAcceptsClient
+	clusterObj, _ := json.Marshal(managedCluster)
 	return runtime.RawExtension{
 		Raw: clusterObj,
 	}
 }
 
 func newManagedClusterObjWithClientConfigs(clientConfig clusterv1.ClientConfig) runtime.RawExtension {
-	spokeCluster := &clusterv1.ManagedCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "testspokecluster",
-		},
-		Spec: clusterv1.ManagedClusterSpec{
-			ManagedClusterClientConfigs: []clusterv1.ClientConfig{clientConfig},
-		},
-	}
-	clusterObj, _ := json.Marshal(spokeCluster)
+	managedCluster := testinghelpers.NewManagedCluster()
+	managedCluster.Spec.ManagedClusterClientConfigs = []clusterv1.ClientConfig{clientConfig}
+	clusterObj, _ := json.Marshal(managedCluster)
 	return runtime.RawExtension{
 		Raw: clusterObj,
 	}

--- a/test/e2e/bindata/bindata.go
+++ b/test/e2e/bindata/bindata.go
@@ -1,9 +1,12 @@
 // Code generated for package bindata by go-bindata DO NOT EDIT. (@generated)
 // sources:
+// deploy/spoke/clusterrole.yaml
 // deploy/spoke/clusterrole_binding.yaml
 // deploy/spoke/deployment.yaml
 // deploy/spoke/kustomization.yaml
 // deploy/spoke/namespace.yaml
+// deploy/spoke/role.yaml
+// deploy/spoke/role_binding.yaml
 // deploy/spoke/secret.yaml
 // deploy/spoke/service_account.yaml
 package bindata
@@ -59,14 +62,42 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
+var _deploySpokeClusterroleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: open-cluster-management:spoke
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "configmaps", "secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+`)
+
+func deploySpokeClusterroleYamlBytes() ([]byte, error) {
+	return _deploySpokeClusterroleYaml, nil
+}
+
+func deploySpokeClusterroleYaml() (*asset, error) {
+	bytes, err := deploySpokeClusterroleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "deploy/spoke/clusterrole.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _deploySpokeClusterrole_bindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:open-cluster-management:spoke
+  name: open-cluster-management:spoke
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: open-cluster-management:spoke
 subjects:
   - kind: ServiceAccount
     name: spoke-agent-sa
@@ -174,7 +205,10 @@ namespace: open-cluster-management
 resources:
 - ./namespace.yaml
 - ./service_account.yaml
+- ./clusterrole.yaml
 - ./clusterrole_binding.yaml
+- ./role.yaml
+- ./role_binding.yaml
 - ./deployment.yaml
 - ./secret.yaml
 
@@ -218,6 +252,65 @@ func deploySpokeNamespaceYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "deploy/spoke/namespace.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _deploySpokeRoleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: open-cluster-management:registration-agent
+  namespace: open-cluster-management
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["", "events.k8s.io"]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]
+`)
+
+func deploySpokeRoleYamlBytes() ([]byte, error) {
+	return _deploySpokeRoleYaml, nil
+}
+
+func deploySpokeRoleYaml() (*asset, error) {
+	bytes, err := deploySpokeRoleYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "deploy/spoke/role.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _deploySpokeRole_bindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: open-cluster-management:registration-agent
+  namespace: open-cluster-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: open-cluster-management:registration-agent
+subjects:
+  - kind: ServiceAccount
+    name: spoke-agent-sa
+    namespace: open-cluster-management
+`)
+
+func deploySpokeRole_bindingYamlBytes() ([]byte, error) {
+	return _deploySpokeRole_bindingYaml, nil
+}
+
+func deploySpokeRole_bindingYaml() (*asset, error) {
+	bytes, err := deploySpokeRole_bindingYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "deploy/spoke/role_binding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -319,10 +412,13 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
+	"deploy/spoke/clusterrole.yaml":         deploySpokeClusterroleYaml,
 	"deploy/spoke/clusterrole_binding.yaml": deploySpokeClusterrole_bindingYaml,
 	"deploy/spoke/deployment.yaml":          deploySpokeDeploymentYaml,
 	"deploy/spoke/kustomization.yaml":       deploySpokeKustomizationYaml,
 	"deploy/spoke/namespace.yaml":           deploySpokeNamespaceYaml,
+	"deploy/spoke/role.yaml":                deploySpokeRoleYaml,
+	"deploy/spoke/role_binding.yaml":        deploySpokeRole_bindingYaml,
 	"deploy/spoke/secret.yaml":              deploySpokeSecretYaml,
 	"deploy/spoke/service_account.yaml":     deploySpokeService_accountYaml,
 }
@@ -370,10 +466,13 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"deploy": {nil, map[string]*bintree{
 		"spoke": {nil, map[string]*bintree{
+			"clusterrole.yaml":         {deploySpokeClusterroleYaml, map[string]*bintree{}},
 			"clusterrole_binding.yaml": {deploySpokeClusterrole_bindingYaml, map[string]*bintree{}},
 			"deployment.yaml":          {deploySpokeDeploymentYaml, map[string]*bintree{}},
 			"kustomization.yaml":       {deploySpokeKustomizationYaml, map[string]*bintree{}},
 			"namespace.yaml":           {deploySpokeNamespaceYaml, map[string]*bintree{}},
+			"role.yaml":                {deploySpokeRoleYaml, map[string]*bintree{}},
+			"role_binding.yaml":        {deploySpokeRole_bindingYaml, map[string]*bintree{}},
 			"secret.yaml":              {deploySpokeSecretYaml, map[string]*bintree{}},
 			"service_account.yaml":     {deploySpokeService_accountYaml, map[string]*bintree{}},
 		}},

--- a/test/e2e/bindata/bindata.go
+++ b/test/e2e/bindata/bindata.go
@@ -62,7 +62,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _deploySpokeClusterrole_bindingYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:open-cluster-management:spoke
+  name: open-cluster-management:spoke
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
As advised by @deads2k
Falling back on `/metrics` port already opened by the registration controller. 
And therefore using the `legacyregistry`. 
And addressed some of the other comments by David.

Working on adding e2e test.